### PR TITLE
Changed behaviour of interactive funcs in vis.mpl

### DIFF
--- a/fatiando/vis/mpl.py
+++ b/fatiando/vis/mpl.py
@@ -173,13 +173,15 @@ def draw_polygon(area, axes, style='-', marker='o', color='k', width=2,
     line.figure.canvas.mpl_connect('key_press_event', erase)
     line.figure.canvas.mpl_connect('motion_notify_event', move)
     pyplot.show()
-    if len(x) < 3:
-        raise ValueError, "Need at least 3 points to make a polygon"
-    if xy2ne:
-        verts = numpy.transpose([y, x])
-    else:
-        verts = numpy.transpose([x, y])
-    return verts
+    def get_vertices(x=x, y=y, xy2ne=xy2ne):
+        if len(x) < 3:
+            raise ValueError, "Need at least 3 points to make a polygon"
+        if xy2ne:
+            verts = numpy.transpose([y, x])
+        else:
+            verts = numpy.transpose([x, y])
+        return verts
+    return get_vertices
 
 def pick_points(area, axes, marker='o', color='k', size=8, xy2ne=False):
     """
@@ -265,11 +267,13 @@ def pick_points(area, axes, marker='o', color='k', size=8, xy2ne=False):
     line.figure.canvas.mpl_connect('button_press_event', pick)
     line.figure.canvas.mpl_connect('key_press_event', erase)
     pyplot.show()
-    if xy2ne:
-        points = numpy.transpose([y, x])
-    else:
-        points = numpy.transpose([x, y])
-    return points
+    def getpoints(x=x, y=y, xy2ne=xy2ne):
+        if xy2ne:
+            points = numpy.transpose([y, x])
+        else:
+            points = numpy.transpose([x, y])
+        return points
+    return getpoints
 
 def draw_layers(area, axes, style='-', marker='o', color='k', width=2):
     """
@@ -382,8 +386,10 @@ def draw_layers(area, axes, style='-', marker='o', color='k', width=2):
     line.figure.canvas.mpl_connect('key_press_event', erase)
     line.figure.canvas.mpl_connect('motion_notify_event', move)
     pyplot.show()
-    thickness = [depths[i + 1] - depths[i] for i in xrange(len(depths) - 1)]
-    return thickness, values
+    def get_thickness(values=values, depths=depths):
+        thick = [depths[i + 1] - depths[i] for i in xrange(len(depths) - 1)]
+        return thick, values
+    return get_thickness
 
 def draw_geolines(area, dlon, dlat, basemap, linewidth=1):
     """


### PR DESCRIPTION
The functions where using pyplot.show() to stay open while the user
picks points, etc. This causes a problem when the plot is interactive
and pyplot.show() doesn't hold the execution (e.g., in IPython with -pylab). 
In those cases, the functions returned empty lists because no points had 
been picked yet. 

The alternative is to return a function instead of the picked points,
etc. This function returns what has been picked when it is called. So in
interactive mode, after the picking is done, just call the function
returned to get the values:

```
from fatiando.vis import mpl
area = [0, 1, 0, 2]
mpl.figure()
getpoints = mpl.pick_points(area, mpl.gca())
points = getpoints()
```

TODO:
- [ ] Update any modules that used the old functionality
- [ ] Update docs
- [ ] Update recipes
