### PR TITLE
Removing logger from cookbook

### DIFF
--- a/cookbook/gravmag_tensor_invariants.py
+++ b/cookbook/gravmag_tensor_invariants.py
@@ -5,7 +5,7 @@ import numpy
 from fatiando import mesher, gridder, gravmag
 from fatiando.vis import mpl
 
-print("Draw the polygons one by one")
+print "Draw the polygons one by one"
 area = [-10000, 10000, -10000, 10000]
 dataarea = [-5000, 5000, -5000, 5000]
 prisms = []

--- a/cookbook/gravmag_tensor_polyprism.py
+++ b/cookbook/gravmag_tensor_polyprism.py
@@ -4,7 +4,7 @@ GravMag: Generate synthetic gradient tensor data from polygonal prisms
 from fatiando import mesher, gridder, gravmag
 from fatiando.vis import mpl, myv
 
-print("Draw the polygons one by one")
+print "Draw the polygons one by one"
 bounds = [-10000, 10000, -10000, 10000, 0, 5000]
 area = bounds[:4]
 axis = mpl.figure().gca()

--- a/cookbook/gravmag_tensor_prism_noisy.py
+++ b/cookbook/gravmag_tensor_prism_noisy.py
@@ -9,10 +9,10 @@ shape = (100,100)
 xp, yp, zp = gridder.regular((-5000, 5000, -5000, 5000), shape, z=-200)
 components = [gravmag.prism.gxx, gravmag.prism.gxy, gravmag.prism.gxz,
               gravmag.prism.gyy, gravmag.prism.gyz, gravmag.prism.gzz]
-print("Calculate the tensor components and contaminate with 5 Eotvos noise")
+print "Calculate the tensor components and contaminate with 5 Eotvos noise"
 ftg = [utils.contaminate(comp(xp, yp, zp, prisms), 5.0) for comp in components]
 
-log.info("Plotting...")
+print "Plotting..."
 mpl.figure(figsize=(14,6))
 mpl.suptitle("Contaminated FTG data")
 names = ['gxx', 'gxy', 'gxz', 'gyy', 'gyz', 'gzz']


### PR DESCRIPTION
I fixed the problem in my branch master.
Now, I send the cookbook corrections in a specific branch.

Update by @leouieda: This PR removes the `fatiando.logger` import that was removed in 0.2 from some cookbook recipes.
