### PR TITLE
Using Miniconda in Travis CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,8 @@ omit =
     */python?.?/*
     */site-packages/nose/*
     /usr/share/pyshared/*
+    */lib-python/?.?/*.py
+    */lib_pypy/_*.py
+    */site-packages/ordereddict.py
+    */site-packages/nose/*
+    */unittest2/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Miniconda stuff shamelessly copied from
+# https://gist.github.com/dan-blanchard/7045057
+# and
+# https://github.com/Jorge-C/ordination/blob/master/.travis.yml
 language: python
 python:
   - 2.7
@@ -5,10 +9,15 @@ python:
 virtualenv:
   system_site_packages: true
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install python-dev python-imaging python-numpy python-scipy python-matplotlib
-  - pip install -q --use-mirrors nose sphinx coverage coveralls
-# Build the docs before installing because sphinx breaks on Cython modules
+  - wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/anaconda/bin:$PATH
+  # Update conda itself
+  - conda update --yes conda
+  - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib nose sphinx imaging
+  - pip install -q --use-mirrors coverage coveralls
+  # Test the docs build before installing because sphinx breaks on Cython modules
   - cd doc; sphinx-build -W -d _build/doctrees -b html . _build/html; cd ..
 install:
   - python setup.py build_ext --inplace


### PR DESCRIPTION
Replaced calls to apt-get with Miniconda
(http://repo.continuum.io/miniconda/) for the latest scipy and numpy.
Tests were breaking because of the old scipy in Travis (0.9.0).

This was copied from:
- https://gist.github.com/dan-blanchard/7045057
- https://github.com/Jorge-C/ordination/blob/master/.travis.yml
