### PR TITLE
Renamed io to datasets

### DIFF
--- a/cookbook/datasets_crust2.0_tesseroid.py
+++ b/cookbook/datasets_crust2.0_tesseroid.py
@@ -1,18 +1,18 @@
 """
-I/O: Fetch the CRUST2.0 model, convert it to tesseroids and calculate its
+Datasets: Fetch the CRUST2.0 model, convert it to tesseroids and calculate its
 gravity signal in parallel
 """
 import time
 from multiprocessing import Pool
-from fatiando import gridder, utils, io
+from fatiando import gridder, utils, datasets
 from fatiando.gravmag import tesseroid
 from fatiando.mesher import Tesseroid
 from fatiando.vis import mpl, myv
 
 # Get the data from their website and convert it to tesseroids
 # Will download the archive and save it with the default name
-archive = io.fetch_crust2()
-model = io.crust2_to_tesseroids(archive)
+archive = datasets.fetch_crust2()
+model = datasets.crust2_to_tesseroids(archive)
 
 # Plot the tesseroid model
 myv.figure(zdown=False)

--- a/cookbook/grid_surfer.py
+++ b/cookbook/grid_surfer.py
@@ -1,19 +1,16 @@
 """
-I/O: Load a Surfer ASCII grid file
+Gridding: Load a Surfer ASCII grid file
 """
-from fatiando import io
+from fatiando import datasets, gridder
 from fatiando.vis import mpl
 
-# Get the data from their website
+# Fetching Bouguer anomaly model data (Surfer ASCII grid file)"
 # Will download the archive and save it with the default name
-print "Fetching Bouguer anomaly model (Surfer ASCII grid file)"
-archive = io.fetch_bouguer_alps_egm()
+archive = datasets.fetch_bouguer_alps_egm()
 
 # Load the GRD file and convert in three numpy-arrays (y, x, bouguer)
-print "Loading the GRD file..."
-y, x, bouguer, shape = io.load_surfer(archive, fmt='ascii')
+y, x, bouguer, shape = gridder.load_surfer(archive, fmt='ascii')
 
-print "Plotting..."
 mpl.figure()
 mpl.axis('scaled')
 mpl.title("Data loaded from a Surfer ASCII grid file")

--- a/cookbook/seismic_wavefd_love_wave.py
+++ b/cookbook/seismic_wavefd_love_wave.py
@@ -4,7 +4,7 @@ medium with a discontinuity (i.e., Moho), generating Love waves.
 """
 import numpy as np
 from matplotlib import animation
-from fatiando import gridder, io
+from fatiando import gridder
 from fatiando.seismic import wavefd
 from fatiando.vis import mpl
 

--- a/doc/api/datasets.rst
+++ b/doc/api/datasets.rst
@@ -1,0 +1,10 @@
+.. _fatiando_datasets:
+.. _fatiando_io:
+
+Fetch data from the internet (``fatiando.datasets``)
+========================================================
+
+.. automodule:: fatiando.datasets
+   :members:
+   :show-inheritance:
+

--- a/doc/api/fatiando.rst
+++ b/doc/api/fatiando.rst
@@ -15,7 +15,7 @@ API Reference: The ``fatiando`` package
     mesher.rst
     gridder.rst
     vis.rst
-    io.rst
+    datasets.rst
     gui.rst
     utils.rst
     constants.rst

--- a/doc/api/io.rst
+++ b/doc/api/io.rst
@@ -1,9 +1,0 @@
-.. _fatiando_io:
-
-Input/Output (``fatiando.io``)
-==============================
-
-.. automodule:: fatiando.io
-   :members:
-   :show-inheritance:
-

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,9 @@ Version 0.2
 * Complete re-implementation of :ref:`fatiando.inversion <fatiando_inversion>`
   and all modules that depended on it. Inversion routines now have a standard
   interface. (`PR 72 <https://github.com/leouieda/fatiando/pull/72>`_)
+* Renamed the ``fatiando.io`` module to
+  :ref:`fatiando.datasets <fatiando_datasets>`
+  (`PR <>`_)
 * :ref:`fatiando.utils.contaminate <fatiando_utils>` can now take multiple data
   vectors and stddevs
 * 2x speed-up of :ref:`fatiando.gravmag.talwani <fatiando_gravmag_talwani>`

--- a/fatiando/__init__.py
+++ b/fatiando/__init__.py
@@ -19,8 +19,8 @@ Modules for gridding, meshing, visualization, user interface, input/output etc:
   Grid generation and operations (e.g., interpolation)
 * :mod:`vis <fatiando.vis>`:
   Plotting utilities for 2D (using matplotlib) and 3D (using mayavi)
-* :mod:`io <fatiando.io>`:
-  Input/Output of models, data sets, etc (fetch from web repositories)
+* :mod:`datasets <fatiando.datasets>`:
+  Fetch and load datasets and models from web repositories
 * :mod:`gui <fatiando.gui>`:
   Graphical user interfaces (still very primitive)
 * :mod:`utils <fatiando.utils>`:

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -17,6 +17,11 @@ Create and operate on grids and profiles.
 * :func:`~fatiando.gridder.interp_at`
 * :func:`~fatiando.gridder.extrapolate_nans`
 
+**Input/Output**
+
+* :func:`~fatiando.gridder.load_surfer`: Read a Surfer grid file and return
+  three 1d numpy arrays and the grid shape
+
 **Misc**
 
 * :func:`~fatiando.gridder.spacing`
@@ -29,6 +34,78 @@ import numpy
 import scipy.interpolate
 import matplotlib.mlab
 
+
+def load_surfer(fname, fmt='ascii'):
+    """
+    Read a Surfer grid file and return three 1d numpy arrays and the grid shape
+
+    Surfer is a contouring, gridding and surface mapping software
+    from GoldenSoftware. The names and logos for Surfer and Golden
+    Software are registered trademarks of Golden Software, Inc.
+
+    http://www.goldensoftware.com/products/surfer
+
+    According to Surfer structure, x and y are horizontal and vertical
+    screen-based coordinates respectively. If the grid is in geographic
+    coordinates, x will be longitude and y latitude. If the coordinates
+    are cartesian, x will be the easting and y the norting coordinates.
+
+    WARNING: This is opposite to the convention used for Fatiando.
+    See io_surfer.py in cookbook.
+
+    Parameters:
+
+    * fname : str
+        Name of the Surfer grid file
+    * fmt : str
+        File type, can be 'ascii' or 'binary'
+
+    Returns:
+
+    * x : 1d-array
+        Value of the horizontal coordinate of each grid point.
+    * y : 1d-array
+        Value of the vertical coordinate of each grid point.
+    * grd : 1d-array
+        Values of the field in each grid point. Field can be for example
+        topography, gravity anomaly etc
+    * shape : tuple = (ny, nx)
+        The number of points in the vertical and horizontal grid dimensions,
+        respectively
+
+    """
+    assert fmt in ['ascii', 'binary'], "Invalid grid format '%s'. Should be \
+        'ascii' or 'binary'." % (fmt)
+    if fmt == 'ascii':
+        # Surfer ASCII grid structure
+        # DSAA            Surfer ASCII GRD ID
+        # nCols nRows     number of columns and rows
+        # xMin xMax       X min max
+        # yMin yMax       Y min max
+        # zMin zMax       Z min max
+        # z11 z21 z31 ... List of Z values
+        with open(fname) as ftext:
+            # DSAA is a Surfer ASCII GRD ID
+            id = ftext.readline()
+            # Read the number of columns (nx) and rows (ny)
+            nx, ny = [int(s) for s in ftext.readline().split()]
+            # Read the min/max value of x (columns/longitue)
+            xmin, xmax = [float(s) for s in ftext.readline().split()]
+            # Read the min/max value of  y(rows/latitude)
+            ymin, ymax = [float(s) for s in ftext.readline().split()]
+            # Read the min/max value of grd
+            zmin, zmax = [float(s) for s in ftext.readline().split()]
+            data = numpy.fromiter((float(i) for line in ftext for i in
+                                   line.split()), dtype='f')
+            grd = numpy.ma.masked_greater_equal(data, 1.70141e+38)
+        # Create x and y numpy arrays
+        x = numpy.linspace(xmin, xmax, nx)
+        y = numpy.linspace(ymin, ymax, ny)
+        x, y = [tmp.ravel() for tmp in numpy.meshgrid(x, y)]
+    if fmt == 'binary':
+        raise NotImplementedError(
+            "Binary file support is not implemented yet.")
+    return x, y, grd, (ny,nx)
 
 def regular(area, shape, z=None):
     """

--- a/fatiando/mesher.py
+++ b/fatiando/mesher.py
@@ -34,8 +34,8 @@ import numpy
 import scipy.special
 import matplotlib.mlab
 
-import fatiando.io
-import fatiando.gridder
+from . import gridder
+from . import utils
 
 
 class GeometricElement(object):
@@ -280,7 +280,7 @@ class SquareMesh(object):
             Name of the physical property
 
         """
-        self.props[prop] = fatiando.io.fromimage(fname, ranges=[vmin, vmax],
+        self.props[prop] = utils.fromimage(fname, ranges=[vmin, vmax],
                 shape=self.shape)[::-1,:].ravel()
 
     def get_xs(self):


### PR DESCRIPTION
Moved `fromimage` to `utils`  and `load_surfer` to `gridder`. Seemed more
appropriate.

Continues what was started in #68.

Resolved #66 
#37 should be modified to use the new layout.
