### PR TITLE
A Grid class to facilitate manipulation of grid data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - export PATH=/home/travis/anaconda/bin:$PATH
     # Update conda itself
     - conda update --yes conda
-    - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib nose sphinx imaging ipython numba pep8==1.6.2
+    - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib nose sphinx imaging ipython numba pep8==1.6.2 six
     - pip install coverage==3.7.1 coveralls==0.5 sphinx_bootstrap_theme==0.4.5
 install:
     - python setup.py build

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ A Python package for modeling and inversion in geophysics.
 .. image:: http://img.shields.io/badge/GITTER-JOIN_CHAT-brightgreen.svg?style=flat-square
     :alt: gitter chat room at https://gitter.im/fatiando/fatiando
     :target: https://gitter.im/fatiando/fatiando
- 
+
 Dependencies
 ------------
 
@@ -42,6 +42,7 @@ To install and run Fatiando, you'll need the following packages:
 * basemap >= 1.0.7
 * gcc >= 4.8.2
 * numba >= 0.17
+* six
 
 You can get all of these on Linux, Mac, and Windows through
 the `Anaconda distribution <http://continuum.io/downloads>`__.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -39,6 +39,7 @@ Fatiando requires the following packages:
 * `matplotlib <http://matplotlib.sourceforge.net/>`_
 * `IPython <http://ipython.org/>`__
 * `numba <http://numba.pydata.org/>`__
+* `six <https://pythonhosted.org/six/>`__
 * `PIL <http://www.pythonware.com/products/pil/>`_
 * `mayavi <http://code.enthought.com/projects/mayavi/>`_
 * A C compiler (preferably GCC or MinGW_ on Windows)
@@ -53,7 +54,7 @@ the many, many, many issues of compiling under Windows.
 Once you have downloaded and installed Anaconda_,
 open a terminal (or ``cmd.exe`` on Windows) and run::
 
-    conda install numpy scipy matplotlib numba ipython basemap imaging mayavi pip
+    conda install numpy scipy matplotlib numba ipython basemap imaging mayavi pip six
 
 Installing Fatiando
 -------------------

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -483,6 +483,9 @@ class Grid(object):
         """
         Make a pseudo-color map of the given attribute.
         """
+        assert self.shape is not None, \
+            "'shape' not set. Can only plot regular grids. " + \
+            "Try method 'interp' to produce a regular grid"
         if isinstance(attribute, str):
             attribute = getattr(self, attribute)
         values = numpy.ma.masked_where(
@@ -513,6 +516,9 @@ class Grid(object):
         """
         Make a filled contour map of the given attribute.
         """
+        assert self.shape is not None, \
+            "'shape' not set. Can only plot regular grids. " + \
+            "Try method 'interp' to produce a regular grid"
         if isinstance(attribute, str):
             attribute = getattr(self, attribute)
         values = numpy.ma.masked_where(
@@ -544,6 +550,9 @@ class Grid(object):
         """
         Make a contour plot of the given attribute
         """
+        assert self.shape is not None, \
+            "'shape' not set. Can only plot regular grids. " + \
+            "Try method 'interp' to produce a regular grid"
         if isinstance(attribute, str):
             attribute = getattr(self, attribute)
         values = numpy.ma.masked_where(

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -215,10 +215,14 @@ class Grid(object):
         return grid
 
     @staticmethod
-    def load_csv(fname, column_names=None, usecols=None, **kwargs):
+    def load_csv(fname, **kwargs):
         """
         Load data from a CSV file.
         """
+        column_names = kwargs.get('column_names', None)
+        usecols = kwargs.get('usecols', None)
+        if 'delimiter' not in kwargs:
+            kwargs['delimiter'] = ';'
         with open(fname) as f:
             # Check if first line contains the column names
             first = f.readline().strip().split(';')
@@ -239,8 +243,8 @@ class Grid(object):
                         column_names = columns
                     else:
                         column_names = [columns[c] for c in usecols]
-            grid = Grid.load_numpy(f, column_names=column_names, binary=False,
-                                   delimiter=';', usecols=usecols, **kwargs)
+                kwargs['column_names'] = column_names
+            grid = Grid.load_numpy(f, **kwargs)
         return grid
 
     @staticmethod

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -677,7 +677,7 @@ def _autocmap(values, autoranges, args):
         args['vmax'] = absmax
     if 'cmap' not in args:
         if diverging:
-            args['cmap'] = pyplot.cm.RdBu_r
+            args['cmap'] = pyplot.cm.RdYlBu_r
         else:
             if sign == 'positive':
                 args['cmap'] = pyplot.cm.Reds

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -276,7 +276,10 @@ class Grid(object):
                 n = shape[0]*shape[1]
             args['height'] = height*numpy.ones(n)
         for attr, value in zip(attributes, data):
-            args[attr] = value
+            # Do all this because the ICGEM grids vary lon first, then lat
+            # But for all else here we need lat first (x), then lon (y)
+            # reshapes further on will rely on this, so fix it when reading
+            args[attr] = value.reshape((shape[1], shape[0])).T.ravel()
         return Grid(**args)
 
     def dump_csv(self, fname, **kwargs):

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -487,6 +487,13 @@ class Grid(object):
                                           extrapolate=extrapolate)
         return self.__class__(x=x, y=y, distance=dist, **args)
 
+    def set_shape(self, shape):
+        """
+        Replace the shape attribute.
+        """
+        self.shape = shape
+        return self
+
     def set_projection(self, proj):
         """
         Specify the Cartopy projection object that corresponds to the

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -161,7 +161,7 @@ class Grid(object):
         return grid
 
     @staticmethod
-    def load_csv(fname, column_names=None, **kwargs):
+    def load_csv(fname, column_names=None, usecols=None, **kwargs):
         """
         Load data from a CSV file.
         """
@@ -181,9 +181,12 @@ class Grid(object):
                 f.seek(0)
             else:
                 if column_names is None:
-                    column_names = columns
+                    if usecols is None:
+                        column_names = columns
+                    else:
+                        column_names = [columns[c] for c in usecols]
             grid = Grid.load_numpy(f, column_names=column_names, binary=False,
-                                   delimiter=';')
+                                   delimiter=';', usecols=usecols, **kwargs)
         return grid
 
     @staticmethod

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -356,7 +356,7 @@ class Grid(object):
         return self.__class__(**args)
 
     def profile(self, point1, point2, npoints, attribute=None,
-                extrapolate=False):
+                extrapolate=False, projection=None):
         """
         Extract a profile between point 1 and point 2.
         """
@@ -364,6 +364,10 @@ class Grid(object):
             attribute = self._attributes
         elif isinstance(attribute, str):
             attribute = [attribute]
+        if projection is not None:
+            x, y = numpy.transpose([point1, point2])
+            y, x = self.projection.transform_points(projection, y, x).T[:2]
+            point1, point2 = numpy.transpose([x, y])
         args = dict(shape=None, projection=self.projection)
         for k in attribute:
             x, y, dist, args[k] = profile(self.x, self.y, getattr(self, k),

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -1,6 +1,13 @@
 """
 Create and operate on grids and profiles.
 
+All the main functionality of this module (and more) is implemented in the
+:class:`~fatiando.gridder.Grid` class.
+Use it to generate grids of points, load from file, plot data, interpolate,
+and work with `Cartopy <http://scitools.org.uk/cartopy/>`__ projections.
+
+You can still use the functions below to achieve some of this functionality.
+
 **Grid generation**
 
 * :func:`~fatiando.gridder.regular`
@@ -32,6 +39,518 @@ Create and operate on grids and profiles.
 
 import numpy
 import scipy.interpolate
+import matplotlib.mlab
+from matplotlib import pyplot
+
+
+class Grid(object):
+    """
+    Grid data generation, manipulation, I/O and plotting.
+    """
+
+    _coord_names = ['x', 'y', 'lon', 'long', 'longitude', 'lat', 'latitude']
+    _special_attributes = ['shape', 'projection', 'lonlat', 'metadata']
+
+    def __init__(self, **kwargs):
+        kwargs = dict((k.lower(), v) for k, v in kwargs.iteritems())
+        added = []
+        for k, v in kwargs.iteritems():
+            if k not in self._special_attributes:
+                v = numpy.asarray(v).ravel()
+            if k in ['lon', 'long', 'longitude']:
+                k = 'lon'
+                if 'y' not in kwargs:
+                    setattr(self, 'y', v)
+                    added.append('y')
+            elif k in ['lat', 'latitude']:
+                k = 'lat'
+                if 'x' not in kwargs:
+                    setattr(self, 'x', v)
+                    added.append('x')
+            added.append(k)
+            setattr(self, k, v)
+        if 'shape' not in added:
+            self.shape = None
+        if 'projection' not in added:
+            self.projection = None
+        if 'x' not in kwargs or 'y' not in kwargs:
+            self.lonlat = True
+        else:
+            self.lonlat = False
+        not_attributes = set(self._coord_names + self._special_attributes)
+        self._attributes = list(set(added).difference(not_attributes))
+        # Check all attributes have the same size
+        sizes = [getattr(self, k).size for k in self._attributes + ['x', 'y']]
+        assert numpy.all(numpy.asarray(sizes) == sizes[0]), \
+            "All attributes and coordinates must have same size"
+        self.size = sizes[0]
+
+    def add_attribute(self, name, value):
+        """
+        Add a column to the grid.
+        """
+        value = numpy.asarray(value).ravel()
+        assert value.size == self.size, "Attribute must have same size as grid"
+        setattr(self, name.lower(), value)
+        self._attributes.append(name)
+        return self
+
+    @staticmethod
+    def regular(area, shape, z=None, lonlat=False, projection=None):
+        """
+        Generate a regular grid
+        """
+        x1, x2, y1, y2 = area
+        ny, nx = shape
+        x, y = numpy.meshgrid(numpy.linspace(x1, x2, nx),
+                              numpy.linspace(y1, y2, ny))
+        args = dict(shape=shape, projection=projection)
+        if lonlat:
+            args['lon'] = y
+            args['lat'] = x
+        else:
+            args['y'] = y
+            args['x'] = x
+        if z is not None:
+            args['z'] = z*numpy.ones(shape[0]*shape[1])
+        return Grid(**args)
+
+    @staticmethod
+    def scatter(area, n, z=None, lonlat=False, projection=None, seed=None):
+        """
+        Generate a random scatter of points.
+        """
+        coords = scatter(area, n, z, seed)
+        x, y = coords[0], coords[1]
+        args = dict(shape=None, projection=projection)
+        if len(coords) == 3:
+            args['z'] = coords[2]
+        if lonlat:
+            args['lon'] = y
+            args['lat'] = x
+        else:
+            args['y'] = y
+            args['x'] = x
+        return Grid(**args)
+
+    @staticmethod
+    def load(fname, **kwargs):
+        """
+        Load data from a file.
+
+        Will try to guess the file type by the extension.
+        If it's an open file, will pass it to
+        :meth:`~fatiando.gridder.Grid.load_numpy`.
+        """
+        grid = None
+        if isinstance(fname, str):
+            # Try to guess the file type from the extension
+            ext = fname.strip().split('.')[-1]
+            if ext == 'gdf':
+                grid = Grid.load_gdf(fname, **kwargs)
+            elif ext == 'csv':
+                grid = Grid.load_csv(fname, **kwargs)
+        if grid is None:
+            if 'binary' not in kwargs:
+                try:
+                    grid = Grid.load_numpy(fname, binary=False, **kwargs)
+                except:
+                    grid = Grid.load_numpy(fname, binary=True, **kwargs)
+            else:
+                grid = Grid.load_numpy(fname, **kwargs)
+        return grid
+
+    @staticmethod
+    def load_csv(fname, column_names=None, **kwargs):
+        """
+        Load data from a CSV file.
+        """
+        with open(fname) as f:
+            # Check if first line contains the column names
+            first = f.readline().strip().split(';')
+            columns = [s.strip() for s in first if s.strip()]
+            numbers = False
+            for item in columns:
+                try:
+                    float(item)
+                    numbers = True
+                except ValueError:
+                    pass
+            if numbers:
+                # Rewind the file to the origin to read later
+                f.seek(0)
+            else:
+                if column_names is None:
+                    column_names = columns
+            grid = Grid.load_numpy(f, column_names=column_names, binary=False,
+                                   delimiter=';')
+        return grid
+
+    @staticmethod
+    def load_numpy(fname, binary=False, column_names=None, **kwargs):
+        """
+        Load data from a numpy saved text or binary file.
+        """
+        if binary:
+            data = numpy.load(fname, **kwargs).T
+        else:
+            kwargs['unpack'] = True
+            data = numpy.loadtxt(fname, **kwargs)
+        if column_names is None:
+            nattr = len(data) - 2
+            attributes = ['data{:d}'.format(i + 1) for i in range(nattr)]
+            column_names = ['x', 'y'] + attributes
+        assert len(column_names) == len(data), "Insuffient column names."
+        args = dict([k, v] for k, v in zip(column_names, data))
+        return Grid(**args)
+
+    @staticmethod
+    def load_gdf(fname, **kwargs):
+        """
+        Load data from an ICGEM .gdf file.
+        """
+        with open(fname) as f:
+            # Read the header and extract metadata
+            metadata = []
+            shape = [None, None]
+            size = None
+            height = None
+            attributes = None
+            attr_line = False
+            for line in f:
+                if line.strip()[:11] == 'end_of_head':
+                    break
+                metadata.append(line)
+                if not line.strip():
+                    attr_line = True
+                    continue
+                if not attr_line:
+                    parts = line.strip().split()
+                    if parts[0] == 'height_over_ell':
+                        height = float(parts[1])
+                    elif parts[0] == 'latitude_parallels':
+                        shape[0] = int(parts[1])
+                    elif parts[0] == 'longitude_parallels':
+                        shape[1] = int(parts[1])
+                    elif parts[0] == 'number_of_gridpoints':
+                        size = int(parts[1])
+                else:
+                    attributes = line.strip().split()
+                    attr_line = False
+            # Read the numerical values
+            data = numpy.loadtxt(f, unpack=True)
+        # Sanity checks
+        if any(n is None for n in shape):
+            shape = None
+        else:
+            shape = tuple(shape)
+            if size is not None and shape[0]*shape[1] != size:
+                raise ValueError(
+                    "Grid shape {} and size read ({})".format(shape, size)
+                    + " are incompatible.")
+        if attributes is None:
+            raise ValueError("Couldn't read column names.")
+        if len(attributes) != len(data):
+            raise ValueError(
+                "Number of columns names ({})".format(len(attributes))
+                + " doesn't match columns read ({}).".format(len(data)))
+        # Make the argument list for the grid
+        args = dict(shape=shape, metadata=''.join(metadata))
+        if (height is not None) and ('height' not in attributes):
+            if shape is None:
+                if size is not None:
+                    n = size
+                else:
+                    n = data[0].size
+            else:
+                n = shape[0]*shape[1]
+            args['height'] = height*numpy.ones(n)
+        for attr, value in zip(attributes, data):
+            args[attr] = value
+        return Grid(**args)
+
+    def dump_csv(self, fname):
+        """
+        Save the data to a CSV file.
+        """
+        if isinstance(fname, str):
+            f = open(fname, 'w')
+        else:
+            f = fname
+        if self.lonlat:
+            column_names = ['latitude', 'longitude']
+        else:
+            column_names = ['x', 'y']
+        column_names.extend(self.get_attributes())
+        f.write('; '.join(column_names))
+        f.write('\n')
+        data = (getattr(self, i) for i in ['x', 'y'] + self.get_attributes())
+        numpy.savetxt(f, numpy.hstack(c.reshape((self.size, 1)) for c in data),
+                      delimiter='; ')
+        if isinstance(fname, str):
+            f.close()
+
+    @property
+    def area(self):
+        """
+        Return the [xmin, xmax, ymin, ymax] limits of the data
+        """
+        return (self.x.min(), self.x.max(), self.y.min(), self.y.max())
+
+    @property
+    def spacing(self):
+        """
+        If the grid is regular (has a ``shape`` attribute), this will be the
+        grid spacing.
+        """
+        if self.shape is None:
+            raise ValueError("Can't calculate spacing for irregular grids."
+                             + " Grid must have a shape attribute.")
+        x1, x2, y1, y2 = self.area
+        ny, nx = self.shape
+        dx = (x2 - x1)/(nx - 1)
+        dy = (y2 - y1)/(ny - 1)
+        return dx, dy
+
+    def get_attributes(self):
+        """
+        Return a list of the attributes (column names) of the grid
+        """
+        return list(self._attributes)
+
+    def interp_at(self, x, y, attribute=None, algorithm='cubic',
+                  extrapolate=False):
+        """
+        Interpolate the grid data on the x, y points given.
+        """
+        if attribute is None:
+            attribute = self._attributes
+        elif isinstance(attribute, str):
+            attribute = [attribute]
+        args = dict(x=x, y=y, projection=self.projection)
+        for k in attribute:
+            args[k] = interp_at(self.x, self.y, getattr(self, k), x, y,
+                                algorithm, extrapolate)
+        return self.__class__(**args)
+
+    def interp(self, shape, attribute=None, area=None, algorithm='cubic',
+               extrapolate=False):
+        """
+        Interpolate the grid data on a regular grid.
+        """
+        ny, nx = shape
+        if area is None:
+            area = self.area
+        x1, x2, y1, y2 = area
+        xs = numpy.linspace(x1, x2, nx)
+        ys = numpy.linspace(y1, y2, ny)
+        xp, yp = [i.ravel() for i in numpy.meshgrid(xs, ys)]
+        if attribute is None:
+            attribute = self._attributes
+        elif isinstance(attribute, str):
+            attribute = [attribute]
+        args = dict(x=xp, y=yp, shape=shape, projection=self.projection)
+        for k in attribute:
+            args[k] = interp_at(self.x, self.y, getattr(self, k), xp, yp,
+                                algorithm, extrapolate)
+        return self.__class__(**args)
+
+    def profile(self, point1, point2, npoints, attribute=None,
+                extrapolate=False):
+        """
+        Extract a profile between point 1 and point 2.
+        """
+        if attribute is None:
+            attribute = self._attributes
+        elif isinstance(attribute, str):
+            attribute = [attribute]
+        args = dict(shape=None, projection=self.projection)
+        for k in attribute:
+            x, y, dist, args[k] = profile(self.x, self.y, getattr(self, k),
+                                          point1, point2, npoints,
+                                          extrapolate=extrapolate)
+        return self.__class__(x=x, y=y, distance=dist, **args)
+
+    def set_projection(self, proj):
+        """
+        Specify the Cartopy projection object that corresponds to the
+        projection of the data.
+        """
+        self.projection = proj
+        return self
+
+    def reproject(self, target_proj):
+        """
+        Transform the coordinates from the current projection to the given
+        projection.
+        """
+        if self.projection is None:
+            raise AttributeError(
+                'Call .set_projection to specify the grid projection first.')
+        coords = target_proj.transform_points(self.projection, self.y, self.x)
+        y, x = coords.T[:2]
+        args = dict((k, getattr(self, k)) for k in self._attributes)
+        grid = self.__class__(x=x, y=y, projection=target_proj,
+                              shape=self.shape, **args)
+        return grid
+
+    def points(self, style='.k', ax=None, **kwargs):
+        """
+        Plot the data points on a map.
+        """
+        if ax is None:
+            if self.projection is None:
+                ax = pyplot.gca()
+            else:
+                ax = pyplot.axes(projection=self.projection)
+        if self.projection is not None:
+            kwargs['transform'] = self.projection
+        plot = ax.plot(self.y, self.x, style, **kwargs)
+        return plot
+
+    def pcolor(self, attribute, autoranges=True, colorbar='vertical', ax=None,
+               basemap=None, **kwargs):
+        """
+        Make a pseudo-color map of the given attribute.
+        """
+        if isinstance(attribute, str):
+            attribute = getattr(self, attribute)
+        values = numpy.ma.masked_where(
+            numpy.isnan(attribute), attribute).reshape(self.shape)
+        _autocmap(values, autoranges, kwargs)
+        if ax is None:
+            if self.projection is None:
+                ax = pyplot.gca()
+            else:
+                ax = pyplot.axes(projection=self.projection)
+        X, Y = self.y.reshape(self.shape), self.x.reshape(self.shape)
+        if basemap is not None:
+            X, Y = basemap(X, Y)
+            plot = basemap.pcolormesh(X, Y, values, **kwargs)
+        else:
+            if 'transform' not in kwargs and self.projection is not None:
+                kwargs['transform'] = self.projection
+            plot = ax.pcolormesh(X, Y, values, **kwargs)
+        if colorbar is not None:
+            _add_colorbar(plot, colorbar, ax)
+        x1, x2, y1, y2 = self.area
+        ax.set_xlim(y1, y2)
+        ax.set_ylim(x1, x2)
+        return plot
+
+    def contourf(self, attribute, levels=10, autoranges=True,
+                 colorbar='vertical', ax=None, basemap=None, **kwargs):
+        """
+        Make a filled contour map of the given attribute.
+        """
+        if isinstance(attribute, str):
+            attribute = getattr(self, attribute)
+        values = numpy.ma.masked_where(
+            numpy.isnan(attribute), attribute).reshape(self.shape)
+        _autocmap(values, autoranges, kwargs)
+        if ax is None:
+            if self.projection is None:
+                ax = pyplot.gca()
+            else:
+                ax = pyplot.axes(projection=self.projection)
+        X, Y = self.y.reshape(self.shape), self.x.reshape(self.shape)
+        if basemap is not None:
+            X, Y = basemap(X, Y)
+            plot = basemap.contourf(X, Y, values, levels, **kwargs)
+        else:
+            if 'transform' not in kwargs and self.projection is not None:
+                kwargs['transform'] = self.projection
+            plot = ax.contourf(X, Y, values, levels, **kwargs)
+        if colorbar is not None:
+            _add_colorbar(plot, colorbar, ax)
+        x1, x2, y1, y2 = self.area
+        ax.set_xlim(y1, y2)
+        ax.set_ylim(x1, x2)
+        return plot
+
+    def contour(self, attribute, levels=10, autoranges=True, ax=None,
+                basemap=None, label=None, clabel=True, style='solid',
+                linewidth=1.0, **kwargs):
+        """
+        Make a contour plot of the given attribute
+        """
+        if isinstance(attribute, str):
+            attribute = getattr(self, attribute)
+        values = numpy.ma.masked_where(
+            numpy.isnan(attribute), attribute).reshape(self.shape)
+        if 'colors' not in kwargs:
+            _autocmap(values, autoranges, kwargs)
+        if ax is None:
+            if self.projection is None:
+                ax = pyplot.gca()
+            else:
+                ax = pyplot.axes(projection=self.projection)
+        X, Y = self.y.reshape(self.shape), self.x.reshape(self.shape)
+        if basemap is not None:
+            X, Y = basemap(X, Y)
+            ct = basemap.contour(X, Y, values, levels, **kwargs)
+        else:
+            if 'transform' not in kwargs and self.projection is not None:
+                kwargs['transform'] = self.projection
+            ct = ax.contour(X, Y, values, levels, **kwargs)
+        if clabel:
+            ct.clabel(fmt='%g')
+        if label is not None:
+            ct.collections[0].set_label(label)
+        if style != 'mixed':
+            for c in ct.collections:
+                c.set_linestyle(style)
+        for c in ct.collections:
+            c.set_linewidth(linewidth)
+        x1, x2, y1, y2 = self.area
+        ax.set_xlim(y1, y2)
+        ax.set_ylim(x1, x2)
+        return ct
+
+
+def _autocmap(values, autoranges, args):
+    """
+    Automatically choose a color map for the given data.
+    Also adjust the value range for diverging colormaps so that 0 is the middle
+    color.
+    """
+    vmax, vmin = numpy.nanmax(values), numpy.nanmin(values)
+    if vmax <= 0 or vmin >= 0:
+        diverging = False
+        if vmax <= 0:
+            sign = 'negative'
+        else:
+            sign = 'positive'
+    else:
+        diverging = True
+    has_vmin_vmax = any(k in args for k in ['vmin', 'vmax'])
+    if autoranges and diverging and not has_vmin_vmax:
+        absmax = numpy.abs([vmax, vmin]).max()
+        args['vmin'] = -absmax
+        args['vmax'] = absmax
+    if 'cmap' not in args:
+        if diverging:
+            args['cmap'] = pyplot.cm.RdBu_r
+        else:
+            if sign == 'positive':
+                args['cmap'] = pyplot.cm.Reds
+            elif sign == 'negative':
+                args['cmap'] = pyplot.cm.Blues_r
+
+
+def _add_colorbar(mappable, orientation, ax):
+    """
+    Add a color bar to the given mappable object (returned by a matplotlib
+    plot command).
+    """
+    cbargs = dict(orientation=orientation)
+    if orientation == 'horizontal':
+        cbargs['pad'] = 0.02
+        cbargs['aspect'] = 50
+    else:
+        cbargs['pad'] = 0
+        cbargs['aspect'] = 20
+    ax.get_figure().colorbar(mappable, ax=ax, **cbargs)
 
 
 def load_surfer(fname, fmt='ascii'):

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -352,22 +352,19 @@ class Grid(object):
         """
         Interpolate the grid data on a regular grid.
         """
-        ny, nx = shape
         if area is None:
             area = self.area
-        x1, x2, y1, y2 = area
-        xs = numpy.linspace(x1, x2, nx)
-        ys = numpy.linspace(y1, y2, ny)
-        xp, yp = [i.ravel() for i in numpy.meshgrid(xs, ys)]
+        grid = Grid.regular(area, shape, z=None, projection=self.projection,
+                            lonlat=self.lonlat)
         if attribute is None:
             attribute = self._attributes
         elif isinstance(attribute, str):
             attribute = [attribute]
-        args = dict(x=xp, y=yp, shape=shape, projection=self.projection)
         for k in attribute:
-            args[k] = interp_at(self.x, self.y, getattr(self, k), xp, yp,
-                                algorithm, extrapolate)
-        return self.__class__(**args)
+            values = interp_at(self.x, self.y, getattr(self, k),
+                               grid.x, grid.y, algorithm, extrapolate)
+            grid.add_attribute(k,  values)
+        return grid
 
     def profile(self, point1, point2, npoints, attribute=None,
                 extrapolate=False, projection=None):

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -518,7 +518,7 @@ class Grid(object):
                               shape=self.shape, **args)
         return grid
 
-    def points(self, style='.k', ax=None, **kwargs):
+    def plot(self, style='.k', ax=None, **kwargs):
         """
         Plot the data points on a map.
         """

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -4,7 +4,7 @@ Create and operate on grids and profiles.
 All the main functionality of this module (and more) is implemented in the
 :class:`~fatiando.gridder.Grid` class.
 Use it to generate grids of points, load from file, plot data, interpolate,
-and work with `Cartopy <http://scitools.org.uk/cartopy/>`__ projections.
+and work with map projections.
 
 You can still use the functions below to achieve some of this functionality.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ IPython >= 2.0.0
 PIL >= 1.1.7
 basemap >= 1.0.7
 numba >= 0.17
+six

--- a/test/test_gridder.py
+++ b/test/test_gridder.py
@@ -62,7 +62,7 @@ def test_grid_regular():
         x1, x2, y1, y2 = area
         ny, nx = shape
         g = gridder.Grid.regular(area, shape)
-        g2 = gridder.Grid.regular(area, shape, lonlat=True)
+        g2 = gridder.Grid.regular(area, shape, latlon=True)
         i = 0
         for yp in np.linspace(y1, y2, ny):
             for xp in np.linspace(x1, x2, nx):

--- a/test/test_gridder.py
+++ b/test/test_gridder.py
@@ -1,0 +1,90 @@
+from __future__ import division
+from fatiando import gridder
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+
+def test_spacing():
+    "gridder.spacing returns correct results"
+    dx, dy = 1.5, 3.3
+    ny, nx = 30, 41
+    area = [0, dx*(nx - 1), 0, dy*(ny - 1)]
+    dy_, dx_ = gridder.spacing(area, (ny, nx))
+    assert_almost_equal(dx_, dx, decimal=10, err_msg="Failed dx")
+    assert_almost_equal(dy_, dy, decimal=10, err_msg="Failed dy")
+
+
+def test_regular():
+    "gridder.regular generates the correct output"
+    shape = (28, 17)
+    areas = [[0, 1, 0, 1],
+             [-1, 1, -1, 1],
+             [-1000, 0, 0, 5000],
+             [0, 501, -1, 0.1]]
+    for area in areas:
+        x1, x2, y1, y2 = area
+        ny, nx = shape
+        x, y = gridder.regular(area, shape)
+        i = 0
+        for yp in np.linspace(y1, y2, ny):
+            for xp in np.linspace(x1, x2, nx):
+                msg = 'area {}: expected {}, {}'.format(area, xp, yp)
+                assert_almost_equal(x[i], xp, decimal=10, err_msg=msg)
+                assert_almost_equal(y[i], yp, decimal=10, err_msg=msg)
+                i += 1
+
+
+def test_scatter():
+    "gridder.scatter returns random results"
+    x, y = gridder.scatter([0, 1, 0, 1], 100)
+    assert not np.abs(x - y).max() < 1e-15, "x and y are equal"
+
+    x1, y1 = gridder.scatter([0, 5, 0, 1], 100, seed=1)
+    x2, y2 = gridder.scatter([0, 5, 0, 1], 100, seed=2)
+    assert not np.abs(x1 - x2).max() < 1e-15, "x1 and x2 are equal"
+    assert not np.abs(y1 - y2).max() < 1e-15, "y1 and y2 are equal"
+
+    x1, y1 = gridder.scatter([0, 5, 0, 1], 100, seed=1)
+    x2, y2 = gridder.scatter([0, 5, 0, 1], 100, seed=1)
+    assert np.abs(x1 - x2).max() < 1e-15, "x1 and x2 are different"
+    assert np.abs(y1 - y2).max() < 1e-15, "y1 and y2 are different"
+
+
+def test_grid_regular():
+    "gridder.Grid.regular generates the correct output"
+    shape = (28, 17)
+    areas = [[0, 1, 0, 1],
+             [-1, 1, -1, 1],
+             [-1000, 0, 0, 5000],
+             [0, 501, -1, 0.1]]
+    for area in areas:
+        x1, x2, y1, y2 = area
+        ny, nx = shape
+        g = gridder.Grid.regular(area, shape)
+        g2 = gridder.Grid.regular(area, shape, lonlat=True)
+        i = 0
+        for yp in np.linspace(y1, y2, ny):
+            for xp in np.linspace(x1, x2, nx):
+                msg = 'area {}: expected {}, {}'.format(area, xp, yp)
+                assert_almost_equal(g.x[i], xp, decimal=10, err_msg=msg)
+                assert_almost_equal(g.y[i], yp, decimal=10, err_msg=msg)
+                assert_almost_equal(g2.lat[i], xp, decimal=10, err_msg=msg)
+                assert_almost_equal(g2.lon[i], yp, decimal=10, err_msg=msg)
+                i += 1
+
+
+def test_grid_scatter():
+    "gridder.Grid.scatter returns random results"
+    g = gridder.Grid.scatter([0, 1, 0, 1], 100)
+    assert not np.abs(g.x - g.y).max() < 1e-15, "x and y are equal"
+
+    g1 = gridder.Grid.scatter([0, 5, 0, 1], 100, seed=1)
+    g2 = gridder.Grid.scatter([0, 5, 0, 1], 100, seed=2)
+    assert not np.abs(g1.x - g2.x).max() < 1e-15, "x1 and x2 are equal"
+    assert not np.abs(g1.y - g2.y).max() < 1e-15, "y1 and y2 are equal"
+
+    g1 = gridder.Grid.scatter([0, 5, 0, 1], 100, seed=1)
+    g2 = gridder.Grid.scatter([0, 5, 0, 1], 100, seed=1)
+    assert np.abs(g1.x - g2.x).max() < 1e-15, "x1 and x2 are different"
+    assert np.abs(g1.y - g2.y).max() < 1e-15, "y1 and y2 are different"


### PR DESCRIPTION
**UPDATE (10/04/2015)**: I gave on this PR because I would end up having to implement too much of the functionality of [pandas](http://pandas.pydata.org/) and [xray](http://xray.readthedocs.org), which is dumb. Instead, I'll take some of the code developed here that is useful and move it to other PRs (automatic colormap selection, colorbar placement, I/O)

**Original prototype**: http://nbviewer.ipython.org/github/fatiando/prototypes/blob/master/grid-class.ipynb

This PR implements a `Grid` class in `fatiando.gridder`. 
The class wraps all the functionality of the existing functions in the module.
It adds extra support for:
* plotting (contour, contourf, pcolor)
* automatic selection of a proper colormap
* adjust the range of diverging colormaps to make the zero value be in the middle of the colorbar
* [Cartopy](http://scitools.org.uk/cartopy/) projections (without importing it)
* Input text, CSV, and [ICGEM](http://icgem.gfz-potsdam.de/ICGEM/) `.gdf`  files
* Output to CSV

There is a draft version of a tutorial to use this class in the [fatiando/tutorials](https://github.com/fatiando/tutorials) repo: http://nbviewer.ipython.org/github/fatiando/tutorials/blob/master/Working_with_grids_and_making_maps.ipynb

TODO:
- [x] Make a `cut` method to extract a slice of the grid
- [x] Plots should raise exception when grid has no `shape`
- [ ] Replace spaces with `_`  or break the string at the first space when importing attributes from file
- [ ] Allow upper case attribute names
- [ ] Option to reproject heights along with coordinates. Pass a `height_attr='name_of_height_data'` argument to `Grid.reproject`
- [ ] Rename `reproject` to just `project`. Reproject sounds weird.
- [x] Allow fancy indexing the `Grid` class to get back sub`Grids` with the desired indexes
- [ ] Make a `concat` method to join 2 or more grids
- [ ] Push I/O methods to functions in the module. `Grid` should just call those functions.
- [ ] Set and get attributes with `['attribute']`
- [ ] Raise error when passed an invalid attribute name (with spaces, first char is number, etc).
- [ ] Add the attribute name to the colorbar using `capitalize` and replacing `_` for ` `

Checklist:
- [ ] Make tests for new code
- [ ] Create/update docstrings
- [ ] Changelog entry
- [ ] Documentation builds properly
- [ ] All tests pass
- [ ] Can be merged