### PR TITLE
Bugfix: stop the weird error  in the tesseroid numba implementation

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,10 @@ Version (development)
 
 **Changes**:
 
+* **BUG FIX**: Avoid weird numba error when tesseroid has zero volume. Let to
+  better sanitizing the input model. Tesseroids with dimensions < 1cm are
+  ignored because they have almost zero gravitational effect
+  (`PR 179 <https://github.com/fatiando/fatiando/pull/179>`__)
 * Ported the tesseroid forward modeling code from Cython to numba. This is
   following the discussion on issue
   `#169 <https://github.com/fatiando/fatiando/issues/169>`__ to make installing

--- a/fatiando/gravmag/tesseroid.py
+++ b/fatiando/gravmag/tesseroid.py
@@ -220,13 +220,23 @@ def _get_engine(engine):
     return module
 
 
-def _get_density(tesseroid, dens):
+def _check_tesseroid(tesseroid, dens):
     """
-    Get the density information from the tesseroid or the given value.
+    Check if the tesseroid is valid and get the right density to use.
+
+    Returns None if the tesseroid should be ignored. Else, return the density
+    that should be used.
     """
     if tesseroid is None:
         return None
     if 'density' not in tesseroid.props and dens is None:
+        return None
+    w, e, s, n, top, bottom = tesseroid.get_bounds()
+    # Check if the dimensions given are valid
+    assert w <= e and s <= n and top >= bottom, \
+        "Invalid tesseroid dimensions {}".format(tesseroid.get_bounds())
+    # Check if the tesseoid has volume > 0
+    if e - w < 1e-7 or n - s < 1e-7 or top - bottom < 1e-3:
         return None
     if dens is not None:
         density = dens
@@ -251,7 +261,7 @@ def _dispatcher(args):
     module = _get_engine(engine)
     func = getattr(module, field)
     for tesseroid in model:
-        density = _get_density(tesseroid, dens)
+        density = _check_tesseroid(tesseroid, dens)
         if density is None:
             continue
         func(lon, sinlat, coslat, radius, tesseroid, density, ratio,
@@ -287,6 +297,9 @@ def potential(lon, lat, height, model, dens=None, ratio=RATIO_V,
               engine='default', njobs=1):
     """
     Calculate the gravitational potential due to a tesseroid model.
+
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
 
     Parameters:
 
@@ -341,6 +354,9 @@ def gx(lon, lat, height, model, dens=None, ratio=RATIO_G, engine='default',
     """
     Calculate the North component of the gravitational attraction.
 
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
+
     Parameters:
 
     * lon, lat, height : arrays
@@ -393,6 +409,9 @@ def gy(lon, lat, height, model, dens=None, ratio=RATIO_G, engine='default',
        njobs=1):
     """
     Calculate the East component of the gravitational attraction.
+
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
 
     Parameters:
 
@@ -452,6 +471,9 @@ def gz(lon, lat, height, model, dens=None, ratio=RATIO_G, engine='default',
         giving positive gz values, **this component only** is calculated
         with **z axis -> Down**.
 
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
+
     Parameters:
 
     * lon, lat, height : arrays
@@ -504,6 +526,9 @@ def gxx(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
         njobs=1):
     """
     Calculate the xx component of the gravity gradient tensor.
+
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
 
     Parameters:
 
@@ -558,6 +583,9 @@ def gxy(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
     """
     Calculate the xy component of the gravity gradient tensor.
 
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
+
     Parameters:
 
     * lon, lat, height : arrays
@@ -610,6 +638,9 @@ def gxz(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
         njobs=1):
     """
     Calculate the xz component of the gravity gradient tensor.
+
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
 
     Parameters:
 
@@ -664,6 +695,9 @@ def gyy(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
     """
     Calculate the yy component of the gravity gradient tensor.
 
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
+
     Parameters:
 
     * lon, lat, height : arrays
@@ -717,6 +751,9 @@ def gyz(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
     """
     Calculate the yz component of the gravity gradient tensor.
 
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
+
     Parameters:
 
     * lon, lat, height : arrays
@@ -769,6 +806,9 @@ def gzz(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
         njobs=1):
     """
     Calculate the zz component of the gravity gradient tensor.
+
+    .. warning:: Tesseroids with dimensions < 1 cm will be ignored to avoid
+        numerical errors.
 
     Parameters:
 

--- a/fatiando/gravmag/tesseroid.py
+++ b/fatiando/gravmag/tesseroid.py
@@ -187,7 +187,7 @@ def _convert_coords(lon, lat, height):
     """
     Convert angles to radians and heights to radius.
 
-    Pre-compute the sine and cossine of latitude because that is what we need
+    Pre-compute the sine and cosine of latitude because that is what we need
     from it.
     """
     # Convert things to radians
@@ -235,7 +235,7 @@ def _check_tesseroid(tesseroid, dens):
     # Check if the dimensions given are valid
     assert w <= e and s <= n and top >= bottom, \
         "Invalid tesseroid dimensions {}".format(tesseroid.get_bounds())
-    # Check if the tesseoid has volume > 0
+    # Check if the tesseroid has volume > 0
     if e - w < 1e-7 or n - s < 1e-7 or top - bottom < 1e-3:
         return None
     if dens is not None:


### PR DESCRIPTION
The error was caused when a tesseroid had 0 volume (w==e, s==n, top==bottom). In such cases, the tesseroid should be ignored from computations since its gravitational effect is zero anyway.

Also added a check if the dimensions are not given inverted (e < w, n < s, top < bottom). This raises an error.

Fixes #178 

## Checklist:

- [x] Make tests for new code
- [x] Create/update docstrings
- [x] Include relevant equations and citations in docstrings
- [x] Code follows PEP8 style conventions
- [x] Code and docs have been spellchecked
- [x] Include new dependencies in docs, requirements.txt, README, and .travis.yml
- [x] Documentation builds properly
- [x] All tests pass
- [x] Can be merged
- [x] Changelog entry