### PR TITLE
Tesseroid forward modeling takes an optional open multiprocessing.Pool

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,11 @@ Version (development)
 
 **Changes**:
 
+* Tesseroid forward modeling functions in ``fatiando.gravmag.tesseroid`` take
+  an optional ``pool`` argument. Use it to pass an open
+  ``multiprocessing.Pool`` for the function to use. Useful to avoid processes
+  spawning overhead when calling the forward modeling many times
+  (`PR 183 <https://github.com/fatiando/fatiando/pull/183>`__)
 * **BUG FIX**: Avoid weird numba error when tesseroid has zero volume. Let to
   better sanitizing the input model. Tesseroids with dimensions < 1cm are
   ignored because they have almost zero gravitational effect

--- a/fatiando/gravmag/tesseroid.py
+++ b/fatiando/gravmag/tesseroid.py
@@ -366,6 +366,11 @@ def potential(lon, lat, height, model, dens=None, ratio=RATIO_V,
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 
@@ -413,6 +418,11 @@ def gx(lon, lat, height, model, dens=None, ratio=RATIO_G, engine='default',
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 
@@ -460,6 +470,11 @@ def gy(lon, lat, height, model, dens=None, ratio=RATIO_G, engine='default',
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 
@@ -512,6 +527,11 @@ def gz(lon, lat, height, model, dens=None, ratio=RATIO_G, engine='default',
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 
@@ -559,6 +579,11 @@ def gxx(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 
@@ -606,6 +631,11 @@ def gxy(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 
@@ -653,6 +683,11 @@ def gxz(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 
@@ -700,6 +735,11 @@ def gyy(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 
@@ -747,6 +787,11 @@ def gyz(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 
@@ -794,6 +839,11 @@ def gzz(lon, lat, height, model, dens=None, ratio=RATIO_GG, engine='default',
     * njobs : int
         Split the computation into *njobs* parts and run it in parallel using
         ``multiprocessing``. If ``njobs=1`` will run the computation in serial.
+    * pool : None or multiprocessing.Pool object
+        If not None, will use this pool to run the computation in parallel
+        instead of creating a new one. You must still specify *njobs* as the
+        number of processes in the pool. Use this to avoid spawning processes
+        on each call to this functions, which can have significant overhead.
 
     Returns:
 

--- a/fatiando/gravmag/tesseroid.py
+++ b/fatiando/gravmag/tesseroid.py
@@ -22,16 +22,16 @@ Gravity
 -------
 
 Forward modeling of gravitational fields is performed by functions:
-:func:`~fatiando.gravmag.prism.potential`,
-:func:`~fatiando.gravmag.prism.gx`,
-:func:`~fatiando.gravmag.prism.gy`,
-:func:`~fatiando.gravmag.prism.gz`,
-:func:`~fatiando.gravmag.prism.gxx`,
-:func:`~fatiando.gravmag.prism.gxy`,
-:func:`~fatiando.gravmag.prism.gxz`,
-:func:`~fatiando.gravmag.prism.gyy`,
-:func:`~fatiando.gravmag.prism.gyz`,
-:func:`~fatiando.gravmag.prism.gzz`
+:func:`~fatiando.gravmag.tesseroid.potential`,
+:func:`~fatiando.gravmag.tesseroid.gx`,
+:func:`~fatiando.gravmag.tesseroid.gy`,
+:func:`~fatiando.gravmag.tesseroid.gz`,
+:func:`~fatiando.gravmag.tesseroid.gxx`,
+:func:`~fatiando.gravmag.tesseroid.gxy`,
+:func:`~fatiando.gravmag.tesseroid.gxz`,
+:func:`~fatiando.gravmag.tesseroid.gyy`,
+:func:`~fatiando.gravmag.tesseroid.gyz`,
+:func:`~fatiando.gravmag.tesseroid.gzz`
 
 The gravitational fields are calculated using the formula of Grombein et al.
 (2013):


### PR DESCRIPTION
The forward modeling functions in gravmag.tesseroid take an option
multiprocessing.Pool object to run things in parallel. This way, a pool
object can be reused for multiple calls, avoiding the repeated spawning
of processes.

Refactored the function code in the process to have less repetition. The
`_dispatcher` function now: checks arguments, spawns the pool if
necessary, dispatches the work, and returns the result.

Fixes #182 

## Checklist:

- [x] Make tests for new code
- [x] Create/update docstrings
- [x] Include relevant equations and citations in docstrings
- [x] Code follows PEP8 style conventions
- [x] Code and docs have been spellchecked
- [x] Include new dependencies in docs, requirements.txt, README, and .travis.yml
- [x] Documentation builds properly
- [x] All tests pass
- [x] Can be merged
- [x] Changelog entry