### PR TITLE
Fix (update) gravmag.transform.upcontinue recipe

### DIFF
--- a/cookbook/gravmag_transform_upcontinue.py
+++ b/cookbook/gravmag_transform_upcontinue.py
@@ -16,20 +16,14 @@ z0 = -100
 x, y, z = gridder.regular(area, shape, z=z0)
 gz = utils.contaminate(prism.gz(x, y, z, model), 0.5, seed=0)
 
-# The how much higher to go
-height = 1000
-
-# Now do the upward continuation using the analytical space domain formula
-gzcont = transform.upcontinue(x, y, gz, shape, height, method='space')
-
-# and using the Fourier transform
-gzcontf = transform.upcontinue(x, y, gz, shape, height, method='fft')
+height = 1000  # How much higher to go
+gzcontf = transform.upcontinue(x, y, gz, shape, height)
 
 # Compute the true value at the new height for comparison
 gztrue = prism.gz(x, y, z - height, model)
 
 args = dict(shape=shape, levels=20, cmap=mpl.cm.RdBu_r)
-fig, axes = mpl.subplots(2, 2)
+fig, axes = mpl.subplots(1, 3, figsize=(12, 3.5))
 axes = axes.ravel()
 mpl.sca(axes[0])
 mpl.title("Original")
@@ -44,15 +38,10 @@ mpl.contourf(y, x, gztrue, **args)
 mpl.colorbar(pad=0).set_label('mGal')
 mpl.m2km()
 mpl.sca(axes[2])
-mpl.title("Continued (Analytical)")
-mpl.axis('scaled')
-mpl.contourf(y, x, gzcont, **args)
-mpl.colorbar(pad=0).set_label('mGal')
-mpl.m2km()
-mpl.sca(axes[3])
 mpl.title("Continued (Fourier)")
 mpl.axis('scaled')
 mpl.contourf(y, x, gzcontf, **args)
 mpl.colorbar(pad=0).set_label('mGal')
 mpl.m2km()
+mpl.tight_layout()
 mpl.show()

--- a/fatiando/gravmag/transform.py
+++ b/fatiando/gravmag/transform.py
@@ -118,10 +118,8 @@ def reduce_to_pole(x, y, data, shape, inc, dec, sinc, sdec):
         rtp = (kz_sqr)/(a1*kx**2 + a2*ky**2 + a3*kx*ky +
                         1j*numpy.sqrt(kz_sqr)*(b1*kx + b2*ky))
     rtp[0, 0] = 0
-    ft = numpy.fft.fft2(numpy.reshape(data, shape))
-    ft_pole = ft*rtp
-    data_pole = numpy.real(numpy.fft.ifft2(ft_pole)).ravel()
-    return data_pole
+    ft_pole = rtp*numpy.fft.fft2(numpy.reshape(data, shape))
+    return numpy.real(numpy.fft.ifft2(ft_pole)).ravel()
 
 
 def upcontinue(x, y, data, shape, height):
@@ -189,6 +187,7 @@ def _upcontinue_space(x, y, data, shape, height):
     historical reasons.
 
     """
+    nx, ny = shape
     dx = (x.max() - x.min())/(nx - 1)
     dy = (y.max() - y.min())/(ny - 1)
     area = dx*dy


### PR DESCRIPTION
The recipe was using the deprecated (#156) space-domain implementation of upward continuation. This PR updates that recipe to use only the FFT version. Also fixes a bug in the space domain implementation that was left behind for reference.