### PR TITLE
Fix doctest error in gravmag.tensor.center_of_mass

### DIFF
--- a/fatiando/gravmag/tensor.py
+++ b/fatiando/gravmag/tensor.py
@@ -187,7 +187,7 @@ def center_of_mass(x, y, z, eigvec1, windows=1, wcenter=None, wmin=None,
     >>> # Now estimate the center of mass
     >>> cm = tensor.center_of_mass(x, y, z, eigenvecs[0])
     >>> cm
-    array([-100.,   20.,  100.])
+    array([-100.,  20., 100.])
 
     """
     if wmin is None:


### PR DESCRIPTION
A doctest failure started appearing in TravisCI because of the number of
spaces between array elements. This is recent and I could reproduce this
on my personal computer.

The fix is simple, just remove spaces from the result array.