### PR TITLE
Pad arrays

### DIFF
--- a/cookbook/grid_pad.py
+++ b/cookbook/grid_pad.py
@@ -9,11 +9,11 @@ import numpy as np
 
 # Generate gridded data
 shape = (101,172)
-x,y,z = gridder.regular((-5000,5000,-5000,5000),shape,z=-150)
-model = [mesher.Prism(-4000,-3000,-4000,-3000,0,2000,{'density':1000}),
-        mesher.Prism(-1000,1000,-1000,1000,0,2000,{'density':-900}),
-        mesher.Prism(2000,4000,3000,4000,0,2000,{'density':1300})]
-gz = prism.gz(x,y,z,model)
+x,y,z = gridder.regular((-5000, 5000, -5000, 5000), shape, z=-150)
+model = [mesher.Prism(-4000, -3000, -4000, -3000, 0, 2000, {'density':1000}),
+        mesher.Prism(-1000, 1000, -1000, 1000, 0, 2000, {'density':-900}),
+        mesher.Prism(2000, 4000, 3000, 4000, 0, 2000, {'density':1300})]
+gz = prism.gz(x, y, z, model)
 gz = gz.reshape(shape)
 
 # Pad arrays with all the padding options
@@ -22,56 +22,58 @@ xy = np.zeros((len(x),2))
 xy[:,0] = x[:]
 xy[:,1] = y[:]
 
-# Pad with zeros
-g,xyp,nps = gridder.pad_array(gz,xy,padtype='0')
+# Pad with zeros (note padtype can be a string or numeric, so long as it
+# can be cast as a float)
+g,xyp,nps = gridder.pad_array(gz, xy, padtype='0')
 pads.append(g.flatten())
 
 # Pad with the mean of each vector
-g,_,_ = gridder.pad_array(gz,xy,padtype='mean')
+g,_,_ = gridder.pad_array(gz, xy, padtype='mean')
 pads.append(g.flatten())
 
 # Pad with the edge of each vector
-g,_,_ = gridder.pad_array(gz,xy,padtype='edge')
+g,_,_ = gridder.pad_array(gz, xy, padtype='edge')
 pads.append(g.flatten())
 
 # Pad with a linear taper
-g,_,_ = gridder.pad_array(gz,xy,padtype='lintaper')
+g,_,_ = gridder.pad_array(gz, xy, padtype='lintaper')
 pads.append(g.flatten())
 
 # Pad with the even reflection
-g,_,_ = gridder.pad_array(gz,xy,padtype='reflection')
+g,_,_ = gridder.pad_array(gz, xy, padtype='reflection')
 pads.append(g.flatten())
 
 # Pad with the odd reflection
-g,_,_ = gridder.pad_array(gz,xy,padtype='OddReflection')
+g,_,_ = gridder.pad_array(gz, xy, padtype='OddReflection')
 pads.append(g.flatten())
 
 # Pad with the odd reflection and a cosine taper (default)
-g,_,_ = gridder.pad_array(gz,xy,padtype='OddReflectionTaper')
+g,_,_ = gridder.pad_array(gz, xy, padtype='OddReflectionTaper')
 pads.append(g.flatten())
 
 shapepad = g.shape
 
 # Generate new meshgrid and plot results
-[Yp,Xp] = np.meshgrid(xyp[1],xyp[0])
+[Yp,Xp] = np.meshgrid(xyp[1], xyp[0])
 yp = Yp.ravel()
 xp = Xp.ravel()
-titles = ['Original','Zero','Mean','Edge','Linear Taper','Reflection',
-        'Odd Reflection','Odd Reflection/Taper']
+titles = ['Original', 'Zero', 'Mean', 'Edge', 'Linear Taper', 'Reflection',
+        'Odd Reflection', 'Odd Reflection/Taper']
 mpl.figure(figsize=(17,9))
 mpl.suptitle('Padding algorithms for a 2D array')
 for ii,p in enumerate(pads):
-    mpl.subplot(2,4,ii+2)
+    mpl.subplot(2, 4, ii+2)
     mpl.axis('scaled')
     mpl.title(titles[ii+1])
-    levels = mpl.contourf(yp*0.001,xp*0.001,p,shapepad,15)
+    levels = mpl.contourf(yp*0.001, xp*0.001, p, shapepad, 15)
     cb = mpl.colorbar()
-    mpl.contour(yp*0.001,xp*0.001,p,shapepad,levels,clabel=False,linewidth=0.1)
-mpl.subplot(2,4,1)
+    mpl.contour(yp*0.001, xp*0.001, p, shapepad, levels, clabel=False,
+        linewidth=0.1)
+mpl.subplot(2, 4, 1)
 mpl.axis('scaled')
 mpl.title(titles[0])
-levels = mpl.contourf(y*0.001,x*0.001,gz,shape,15)
+levels = mpl.contourf(y*0.001, x*0.001, gz, shape, 15)
 cb = mpl.colorbar()
-mpl.contour(y*0.001,x*0.001,gz,shape,levels,clabel=False,linewidth=0.1)
+mpl.contour(y*0.001, x*0.001, gz, shape, levels, clabel=False, linewidth=0.1)
 mpl.show()
 

--- a/cookbook/grid_pad.py
+++ b/cookbook/grid_pad.py
@@ -1,0 +1,77 @@
+"""
+Gridding: Pad gridded data
+"""
+
+from fatiando import mesher,gridder
+from fatiando.gravmag import prism
+from fatiando.vis import mpl
+import numpy as np
+
+# Generate gridded data
+shape = (101,172)
+x,y,z = gridder.regular((-5000,5000,-5000,5000),shape,z=-150)
+model = [mesher.Prism(-4000,-3000,-4000,-3000,0,2000,{'density':1000}),
+        mesher.Prism(-1000,1000,-1000,1000,0,2000,{'density':-900}),
+        mesher.Prism(2000,4000,3000,4000,0,2000,{'density':1300})]
+gz = prism.gz(x,y,z,model)
+gz = gz.reshape(shape)
+
+# Pad arrays with all the padding options
+pads = []
+xy = np.zeros((len(x),2))
+xy[:,0] = x[:]
+xy[:,1] = y[:]
+
+# Pad with zeros
+g,xyp,nps = gridder.pad_array(xy,gz,padtype='0')
+pads.append(g.flatten())
+
+# Pad with the mean of each vector
+g,_,_ = gridder.pad_array(xy,gz,padtype='mean')
+pads.append(g.flatten())
+
+# Pad with the edge of each vector
+g,_,_ = gridder.pad_array(xy,gz,padtype='edge')
+pads.append(g.flatten())
+
+# Pad with a linear taper
+g,_,_ = gridder.pad_array(xy,gz,padtype='lintaper')
+pads.append(g.flatten())
+
+# Pad with the even reflection
+g,_,_ = gridder.pad_array(xy,gz,padtype='reflection')
+pads.append(g.flatten())
+
+# Pad with the odd reflection
+g,_,_ = gridder.pad_array(xy,gz,padtype='OddReflection')
+pads.append(g.flatten())
+
+# Pad with the odd reflection and a cosine taper (default)
+g,_,_ = gridder.pad_array(xy,gz,padtype='OddReflectionTaper')
+pads.append(g.flatten())
+
+shapepad = g.shape
+
+# Generate new meshgrid and plot results
+[Yp,Xp] = np.meshgrid(xyp[1],xyp[0])
+yp = Yp.ravel()
+xp = Xp.ravel()
+titles = ['Original','Zero','Mean','Edge','Linear Taper','Reflection',
+        'Odd Reflection','Odd Reflection/Taper']
+mpl.figure(figsize=(17,9))
+mpl.suptitle('Padding algorithms for a 2D array')
+for ii,p in enumerate(pads):
+    mpl.subplot(2,4,ii+2)
+    mpl.axis('scaled')
+    mpl.title(titles[ii+1])
+    levels = mpl.contourf(yp*0.001,xp*0.001,p,shapepad,15)
+    cb = mpl.colorbar()
+    mpl.contour(yp*0.001,xp*0.001,p,shapepad,levels,clabel=False,linewidth=0.1)
+mpl.subplot(2,4,1)
+mpl.axis('scaled')
+mpl.title(titles[0])
+levels = mpl.contourf(y*0.001,x*0.001,gz,shape,15)
+cb = mpl.colorbar()
+mpl.contour(y*0.001,x*0.001,gz,shape,levels,clabel=False,linewidth=0.1)
+mpl.show()
+

--- a/cookbook/grid_pad.py
+++ b/cookbook/grid_pad.py
@@ -52,7 +52,7 @@ g, _ = gridder.pad_array(gz, padtype='OddReflectionTaper')
 pads.append(g.flatten())
 
 # Get coordinate vectors
-xyp = gridder.padcoords(xy, gz.shape, nps)
+xyp = gridder.pad_coords(xy, gz.shape, nps)
 
 shapepad = g.shape
 

--- a/cookbook/grid_pad.py
+++ b/cookbook/grid_pad.py
@@ -2,73 +2,76 @@
 Gridding: Pad gridded data
 """
 
-from fatiando import mesher,gridder
+from fatiando import mesher, gridder
 from fatiando.gravmag import prism
 from fatiando.vis import mpl
 import numpy as np
 
 # Generate gridded data
-shape = (101,172)
-x,y,z = gridder.regular((-5000, 5000, -5000, 5000), shape, z=-150)
-model = [mesher.Prism(-4000, -3000, -4000, -3000, 0, 2000, {'density':1000}),
-        mesher.Prism(-1000, 1000, -1000, 1000, 0, 2000, {'density':-900}),
-        mesher.Prism(2000, 4000, 3000, 4000, 0, 2000, {'density':1300})]
+shape = (101, 172)
+x, y, z = gridder.regular((-5000, 5000, -5000, 5000), shape, z=-150)
+model = [mesher.Prism(-4000, -3000, -4000, -3000, 0, 2000, {'density': 1000}),
+        mesher.Prism(-1000, 1000, -1000, 1000, 0, 2000, {'density': -900}),
+        mesher.Prism(2000, 4000, 3000, 4000, 0, 2000, {'density': 1300})]
 gz = prism.gz(x, y, z, model)
 gz = gz.reshape(shape)
 
 # Pad arrays with all the padding options
 pads = []
-xy = np.zeros((len(x),2))
-xy[:,0] = x[:]
-xy[:,1] = y[:]
+xy = [x, y]
 
-# Pad with zeros (note padtype can be a string or numeric, so long as it
-# can be cast as a float)
-g,xyp,nps = gridder.pad_array(gz, xy, padtype='0')
+# Pad with zeros, or any other number 
+# (note padtype can be a string or numeric, so long as it
+# can be cast as a float.)  For example, both 0 and '0' are valid, as 
+# would be any other number.
+g, nps = gridder.pad_array(gz, padtype='0')
 pads.append(g.flatten())
 
 # Pad with the mean of each vector
-g,_,_ = gridder.pad_array(gz, xy, padtype='mean')
+g, _ = gridder.pad_array(gz, padtype='mean')
 pads.append(g.flatten())
 
 # Pad with the edge of each vector
-g,_,_ = gridder.pad_array(gz, xy, padtype='edge')
+g, _ = gridder.pad_array(gz, padtype='edge')
 pads.append(g.flatten())
 
 # Pad with a linear taper
-g,_,_ = gridder.pad_array(gz, xy, padtype='lintaper')
+g, _ = gridder.pad_array(gz, padtype='lintaper')
 pads.append(g.flatten())
 
 # Pad with the even reflection
-g,_,_ = gridder.pad_array(gz, xy, padtype='reflection')
+g, _ = gridder.pad_array(gz, padtype='reflection')
 pads.append(g.flatten())
 
 # Pad with the odd reflection
-g,_,_ = gridder.pad_array(gz, xy, padtype='OddReflection')
+g, _ = gridder.pad_array(gz, padtype='OddReflection')
 pads.append(g.flatten())
 
 # Pad with the odd reflection and a cosine taper (default)
-g,_,_ = gridder.pad_array(gz, xy, padtype='OddReflectionTaper')
+g, _ = gridder.pad_array(gz, padtype='OddReflectionTaper')
 pads.append(g.flatten())
+
+# Get coordinate vectors
+xyp = gridder.padcoords(xy, gz.shape, nps)
 
 shapepad = g.shape
 
 # Generate new meshgrid and plot results
-[Yp,Xp] = np.meshgrid(xyp[1], xyp[0])
+[Yp, Xp] = np.meshgrid(xyp[1], xyp[0])
 yp = Yp.ravel()
 xp = Xp.ravel()
 titles = ['Original', 'Zero', 'Mean', 'Edge', 'Linear Taper', 'Reflection',
         'Odd Reflection', 'Odd Reflection/Taper']
-mpl.figure(figsize=(17,9))
+mpl.figure(figsize=(17, 9))
 mpl.suptitle('Padding algorithms for a 2D array')
-for ii,p in enumerate(pads):
+for ii, p in enumerate(pads):
     mpl.subplot(2, 4, ii+2)
     mpl.axis('scaled')
     mpl.title(titles[ii+1])
     levels = mpl.contourf(yp*0.001, xp*0.001, p, shapepad, 15)
     cb = mpl.colorbar()
     mpl.contour(yp*0.001, xp*0.001, p, shapepad, levels, clabel=False,
-        linewidth=0.1)
+                linewidth=0.1)
 mpl.subplot(2, 4, 1)
 mpl.axis('scaled')
 mpl.title(titles[0])
@@ -76,4 +79,3 @@ levels = mpl.contourf(y*0.001, x*0.001, gz, shape, 15)
 cb = mpl.colorbar()
 mpl.contour(y*0.001, x*0.001, gz, shape, levels, clabel=False, linewidth=0.1)
 mpl.show()
-

--- a/cookbook/grid_pad.py
+++ b/cookbook/grid_pad.py
@@ -23,31 +23,31 @@ xy[:,0] = x[:]
 xy[:,1] = y[:]
 
 # Pad with zeros
-g,xyp,nps = gridder.pad_array(xy,gz,padtype='0')
+g,xyp,nps = gridder.pad_array(gz,xy,padtype='0')
 pads.append(g.flatten())
 
 # Pad with the mean of each vector
-g,_,_ = gridder.pad_array(xy,gz,padtype='mean')
+g,_,_ = gridder.pad_array(gz,xy,padtype='mean')
 pads.append(g.flatten())
 
 # Pad with the edge of each vector
-g,_,_ = gridder.pad_array(xy,gz,padtype='edge')
+g,_,_ = gridder.pad_array(gz,xy,padtype='edge')
 pads.append(g.flatten())
 
 # Pad with a linear taper
-g,_,_ = gridder.pad_array(xy,gz,padtype='lintaper')
+g,_,_ = gridder.pad_array(gz,xy,padtype='lintaper')
 pads.append(g.flatten())
 
 # Pad with the even reflection
-g,_,_ = gridder.pad_array(xy,gz,padtype='reflection')
+g,_,_ = gridder.pad_array(gz,xy,padtype='reflection')
 pads.append(g.flatten())
 
 # Pad with the odd reflection
-g,_,_ = gridder.pad_array(xy,gz,padtype='OddReflection')
+g,_,_ = gridder.pad_array(gz,xy,padtype='OddReflection')
 pads.append(g.flatten())
 
 # Pad with the odd reflection and a cosine taper (default)
-g,_,_ = gridder.pad_array(xy,gz,padtype='OddReflectionTaper')
+g,_,_ = gridder.pad_array(gz,xy,padtype='OddReflectionTaper')
 pads.append(g.flatten())
 
 shapepad = g.shape

--- a/cookbook/grid_pad.py
+++ b/cookbook/grid_pad.py
@@ -52,14 +52,13 @@ g, _ = gridder.pad_array(gz, padtype='OddReflectionTaper')
 pads.append(g.flatten())
 
 # Get coordinate vectors
-xyp = gridder.pad_coords(xy, gz.shape, nps)
+N = gridder.pad_coords(xy, gz.shape, nps)
 
 shapepad = g.shape
 
 # Generate new meshgrid and plot results
-[Yp, Xp] = np.meshgrid(xyp[1], xyp[0])
-yp = Yp.ravel()
-xp = Xp.ravel()
+yp = N[1]
+xp = N[0]
 titles = ['Original', 'Zero', 'Mean', 'Edge', 'Linear Taper', 'Reflection',
           'Odd Reflection', 'Odd Reflection/Taper']
 mpl.figure(figsize=(17, 9))

--- a/cookbook/grid_pad.py
+++ b/cookbook/grid_pad.py
@@ -11,8 +11,8 @@ import numpy as np
 shape = (101, 172)
 x, y, z = gridder.regular((-5000, 5000, -5000, 5000), shape, z=-150)
 model = [mesher.Prism(-4000, -3000, -4000, -3000, 0, 2000, {'density': 1000}),
-        mesher.Prism(-1000, 1000, -1000, 1000, 0, 2000, {'density': -900}),
-        mesher.Prism(2000, 4000, 3000, 4000, 0, 2000, {'density': 1300})]
+         mesher.Prism(-1000, 1000, -1000, 1000, 0, 2000, {'density': -900}),
+         mesher.Prism(2000, 4000, 3000, 4000, 0, 2000, {'density': 1300})]
 gz = prism.gz(x, y, z, model)
 gz = gz.reshape(shape)
 
@@ -20,9 +20,9 @@ gz = gz.reshape(shape)
 pads = []
 xy = [x, y]
 
-# Pad with zeros, or any other number 
+# Pad with zeros, or any other number
 # (note padtype can be a string or numeric, so long as it
-# can be cast as a float.)  For example, both 0 and '0' are valid, as 
+# can be cast as a float.)  For example, both 0 and '0' are valid, as
 # would be any other number.
 g, nps = gridder.pad_array(gz, padtype='0')
 pads.append(g.flatten())
@@ -61,7 +61,7 @@ shapepad = g.shape
 yp = Yp.ravel()
 xp = Xp.ravel()
 titles = ['Original', 'Zero', 'Mean', 'Edge', 'Linear Taper', 'Reflection',
-        'Odd Reflection', 'Odd Reflection/Taper']
+          'Odd Reflection', 'Odd Reflection/Taper']
 mpl.figure(figsize=(17, 9))
 mpl.suptitle('Padding algorithms for a 2D array')
 for ii, p in enumerate(pads):

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,12 +10,11 @@ Version 0.5
 
 **Changes**:
 
-* **Pad Arrays** ``fatiando.gridder``. Added several functions for padding
-  arrays of arbitrary dimension. ``fatiando.gridder.pad_array`` pads an array
-  with a variety of padding and taper options.
-  ``fatiando.gridder.unpad_array`` returns the original, unpadded array.
-  ``fatiando.gridder.padcoords`` pads the coordinate vectors associated with 
-  the arrays padded above. Added Kass in the contributors.
+* Added several functions for padding arrays of arbitrary dimension.
+  ``fatiando.gridder.pad_array`` pads an array with a variety of padding and
+  taper options.  ``fatiando.gridder.unpad_array`` returns the original,
+  unpadded array.  ``fatiando.gridder.pad_coords`` pads the coordinate vectors
+  associated with the arrays padded above. Added Kass in the contributors.
   (`PR 239 <https://github.com/fatiando/fatiando/pull/239>`__)
 * Better navigation for long pages in the docs by adding a sidebar with links
   to subsections.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,13 @@ Version 0.5
 
 **Changes**:
 
+* **Pad Arrays** ``fatiando.gridder``. Added several functions for padding
+  arrays of arbitrary dimension. ``fatiando.gridder.pad_array`` pads an array
+  with a variety of padding and taper options.
+  ``fatiando.gridder.unpad_array`` returns the original, unpadded array.
+  ``fatiando.gridder.padcoords`` pads the coordinate vectors associated with 
+  the arrays padded above. Added Kass in the contributors.
+  (`PR 239 <https://github.com/fatiando/fatiando/pull/239>`__)
 * Better navigation for long pages in the docs by adding a sidebar with links
   to subsections.
   (`PR 275 <https://github.com/fatiando/fatiando/pull/275>`__)

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -13,6 +13,7 @@ A (hopefully) updated list of people who contributed to Fatiando a Terra:
 * Graham Markall - Continuum Analytics, Inc.
 * `Martin Bentley`_ - Nelson Mandela Metropolitan University, South Africa and AEON, South Africa
 * `Victor Almeida`_ - UERJ, Brazil.
+* `M. Andy Kass`_ - United States Geological Survey, USA
 
 .. _Leonardo Uieda: http://www.leouieda.com
 .. _Vanderlei Coelho de Oliveira Junior: http://fatiando.org/people/oliveira-jr
@@ -21,3 +22,4 @@ A (hopefully) updated list of people who contributed to Fatiando a Terra:
 .. _André Ferreira: http://fatiando.org/people/ferreira
 .. _Martin Bentley: https://twitter.com/astonsplat
 .. _Victor Almeida: http://www.pinga-lab.org/people/victor-almeida.html
+.. _M. Andy Kass: https://twitter.com/drandykass

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -85,7 +85,7 @@ def load_surfer(fname, fmt='ascii'):
             # Read the number of columns (ny) and rows (nx)
             ny, nx = [int(s) for s in ftext.readline().split()]
             shape = (nx, ny)
-            # Read the min/max value of columns/longitue (y direction)
+            # Read the min/max value of columns/longitude (y direction)
             ymin, ymax = [float(s) for s in ftext.readline().split()]
             # Read the min/max value of rows/latitude (x direction)
             xmin, xmax = [float(s) for s in ftext.readline().split()]
@@ -470,16 +470,17 @@ def pad_array(a, xy=None, npd=None, padtype='OddReflectionTaper'):
 
     Parameters:
 
-    * xy : N-D array (optional)
-        [MxN] array where M is the number of observation points and N is the 
-        dimension.  This is effectively a concatinated xp,yp, etc...
     * a : numpy array
         numpy array (N-D) to be padded
-    * npd : optional tuple
+    * xy : N-D array (optional)
+        [MxN] array where M is the number of observation points and N is the 
+        dimension.  This is effectively a concatenated xp,yp, etc...
+    * npd : tuple (optional)
         Optional tuple containing the total number of desired elements in each
         dimension
-    * padtype : optional string
+    * padtype : string (optional)
         String describing what to pad the new values with. Options:
+
         [ OddReflectionTaper | OddReflection | Reflection | value | LinTaper
         | edge | mean ]
             OddReflectionTaper - Generates odd reflection then tapers to the 
@@ -503,6 +504,7 @@ def pad_array(a, xy=None, npd=None, padtype='OddReflectionTaper'):
         Padded array. The array core is a deep copy of the original array
     * cp : list
         List of coordinate arrays containing the extrapolated coordinate values
+        Returns None if xy not provided
     * nps : list
         List of tuples containing the number of elements padded onto each 
         dimension.

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -514,6 +514,14 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
         >>> nps
         [(2, 1)]
 
+        >>> shape = (5, 6)
+        >>> z = numpy.ones(shape)
+        >>> zpad, nps = pad_array(z, padtype='5')
+        >>> zpad.shape
+        (8, 8)
+        >>> nps
+        [(2, 1), (1, 1)]
+
     """
 
     # Test to make sure padtype is valid
@@ -680,7 +688,6 @@ def pad_coords(xy, shape, nps):
         array([-10.,  -5.,   0.,   5.,  10.])
         >>> y.reshape(shape)[0,:]
         array([-20., -16., -12.,  -8.,  -4.,   0.])
-        # Pad the coordinate vectors
         >>> xy = [x, y]
         >>> [xp, yp] = pad_coords(xy, shape, nps)
         >>> xp

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -664,6 +664,12 @@ def pad_coords(xy, shape, nps):
     this function takes a list of coordinate vectors and pads them using the
     same discretization.
 
+    .. note:: The returned list contains n vectors, where n is the number
+        of dimensions.  Each list element is a single vector containing
+        the coordinates of the points in the respective dimension.  See the
+        example below for how to convert to flattened meshgrid-style
+        (similar to the output of :func:`fatiando.gridder.regular`) vectors.
+
     Parameters:
 
     * xy : list
@@ -680,6 +686,8 @@ def pad_coords(xy, shape, nps):
 
     Examples:
 
+    Construct padded arrays
+
         >>> shape = (5, 6)
         >>> x, y, z = regular((-10,10,-20,0), shape, z=-25)
         >>> gz = numpy.zeros(shape)
@@ -694,6 +702,18 @@ def pad_coords(xy, shape, nps):
         array([-20., -15., -10.,  -5.,   0.,   5.,  10.,  15.])
         >>> yp
         array([-24., -20., -16., -12.,  -8.,  -4.,   0.,   4.])
+
+    Convert padded arrays to the flattened meshgrid style
+
+        >>> shape = (5, 6)
+        >>> x, y, z = regular((-10,10,-20,0), shape, z=-25)
+        >>> gz = numpy.zeros(shape)
+        >>> gzpad, nps = pad_array(gz)
+        >>> xy = [x, y]
+        >>> [xp, yp] = pad_coords(xy, shape, nps)
+        >>> [Y, X] = numpy.meshgrid(yp, xp)
+        >>> ypad = Y.ravel()
+        >>> xpad = X.ravel()
 
     """
     coords = []

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -522,7 +522,6 @@ def pad_array(xy, a, np=None, padtype='OddReflectionTaper'):
     # Compute numbers to pad on the left and right side of the array along
     # each dimension
     nps = []
-    print npt
     for ii in range(0,nd):
         nps.append((int(numpy.ceil((npt[ii]-a.shape[ii])/2.)),
             int(numpy.floor((npt[ii]-a.shape[ii])/2.))))
@@ -598,10 +597,16 @@ def unpad_array(a,nps,cp=None):
 
     # xkcd.com/1597
 
+    # Remove padding from the n-d array
+    o = []
+    for ii in numpy.arange(a.ndim):
+        o.append(slice(nps[ii][0],a.shape[ii]-nps[ii][1]))
+    b = a[o]
+    print b.shape
+    
+    # Remove padding from coordinate vectors, if given
 
-
-
-    return 42
+    return b
 
 def _padcoords(xy,s,nps):
     # Define vector for coordinates for each dimension
@@ -629,6 +634,11 @@ def _padcvec(x,n,dx):
         xp[jj] = x[-1] + (dx * (ii + 1))
     return xp
 
+def _unpadcvec(x,n):
+    # Takes a vector, x, and a tuple, n, and removes n[0] elements from the 
+    # left and n[1] to the right
+    
+    return x[n[0]:len(x)-n[1]]
             
 def _costaper(a,lp,rp):
     # This takes an array and applies a cosine taper to each end.

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -565,7 +565,7 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
     if _is_number(padtype):
         # Pad with value
         ap = numpy.pad(a, nps, mode='constant',
-                       constant_values=(float(padtype),float(padtype)))
+                       constant_values=(float(padtype), float(padtype)))
     elif padtype.lower() == 'mean':
         # Pad with the mean
         ap = numpy.pad(a, nps, mode='mean')

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -453,7 +453,7 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
 
     The function takes an array of arbitrary dimension and pads it either to
     the dimensions given by the tuple npd, or to the next power of 2 if npd is
-    not given. 
+    not given.
 
     An odd reflection with a cosine taper is the author's preferred method of
     padding for Fourier operations.  The odd reflection optimally preserves
@@ -508,7 +508,7 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
 
     # Test to make sure padtype is valid
     padopts = ['oddreflectiontaper', 'oddreflection', 'reflection',
-                'lintaper', 'edge', 'value', 'mean']
+               'lintaper', 'edge', 'value', 'mean']
     # API Note:
     # If one wishes to add more options to the padding, use the following
     # checklist to make sure all the sections are consistent.
@@ -547,8 +547,8 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
         for ii in range(0, len(npt)):
             if npt[ii] <= a.shape[ii]:
                 raise ValueError(
-                        'Desired padding is less than array ' +
-                        'length along dimension' + str(ii) + '.')
+                    'Desired padding is less than array ' +
+                    'length along dimension' + str(ii) + '.')
     # Compute numbers to pad on the left and right side of the array along
     # each dimension
     nps = []
@@ -564,7 +564,7 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
     if _is_number(padtype):
         # Pad with value
         ap = numpy.pad(a, nps, mode='constant',
-                        constant_values=float(padtype))
+                       constant_values=float(padtype))
     elif padtype.lower() == 'mean':
         # Pad with the mean
         ap = numpy.pad(a, nps, mode='mean')
@@ -577,11 +577,11 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
     elif padtype.lower() == 'reflection':
         # Pad with even reflection
         ap = numpy.pad(a, nps, mode='reflect',
-                        reflect_type='even')
+                       reflect_type='even')
     elif padtype.lower() == 'oddreflection':
         # Pad with odd reflection
         ap = numpy.pad(a, nps, mode='reflect',
-                        reflect_type='odd')
+                       reflect_type='odd')
     elif padtype.lower() == 'oddreflectiontaper':
         # Pad with odd reflection and a cosine taper to mean
         ap = (numpy.pad(a, nps, mode='reflect',

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -664,11 +664,9 @@ def pad_coords(xy, shape, nps):
     this function takes a list of coordinate vectors and pads them using the
     same discretization.
 
-    .. note:: The returned list contains n vectors, where n is the number
-        of dimensions.  Each list element is a single vector containing
-        the coordinates of the points in the respective dimension.  See the
-        example below for how to convert to flattened meshgrid-style
-        (similar to the output of :func:`fatiando.gridder.regular`) vectors.
+    .. note:: This function returns a list of arrays in the same format
+    as, for example, :func:`~fatiando.gridder.regular`.  It is a list of
+    flattened meshgrids for each vector in the same order as was input.
 
     Parameters:
 
@@ -676,8 +674,9 @@ def pad_coords(xy, shape, nps):
         List of arrays of coordinates
     * shape : tuple
         Size of original array
-    * nps : tuple
-        Size of padded array
+    * nps : list
+        List of tuples containing the number of elements padded onto each
+            dimension (uses output from :func:`~fatiando.gridder.pad_array`).
 
     Returns:
 
@@ -697,23 +696,11 @@ def pad_coords(xy, shape, nps):
         >>> y.reshape(shape)[0,:]
         array([-20., -16., -12.,  -8.,  -4.,   0.])
         >>> xy = [x, y]
-        >>> [xp, yp] = pad_coords(xy, shape, nps)
-        >>> xp
+        >>> N = pad_coords(xy, shape, nps)
+        >>> N[0].reshape(gzpad.shape)[:,0]
         array([-20., -15., -10.,  -5.,   0.,   5.,  10.,  15.])
-        >>> yp
+        >>> N[1].reshape(gzpad.shape)[0,:]
         array([-24., -20., -16., -12.,  -8.,  -4.,   0.,   4.])
-
-    Convert padded arrays to the flattened meshgrid style
-
-        >>> shape = (5, 6)
-        >>> x, y, z = regular((-10,10,-20,0), shape, z=-25)
-        >>> gz = numpy.zeros(shape)
-        >>> gzpad, nps = pad_array(gz)
-        >>> xy = [x, y]
-        >>> [xp, yp] = pad_coords(xy, shape, nps)
-        >>> [Y, X] = numpy.meshgrid(yp, xp)
-        >>> ypad = Y.ravel()
-        >>> xpad = X.ravel()
 
     """
     coords = []
@@ -726,8 +713,12 @@ def pad_coords(xy, shape, nps):
             coords.append(xy[ii].reshape(shape).transpose().take(0, axis=ii))
         d.append(coords[ii][1] - coords[ii][0])
         coordspad.append(_padcvec(coords[ii], nps[ii], d[ii]))
+    M = numpy.meshgrid(*[a for a in tuple(coordspad)[::-1]])
+    N = []
+    for a in M:
+        N.append(a.ravel())
 
-    return coordspad
+    return N[::-1]
 
 
 def _padcvec(x, n, dx):

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -565,13 +565,13 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
     if _is_number(padtype):
         # Pad with value
         ap = numpy.pad(a, nps, mode='constant',
-                       constant_values=float(padtype))
+                       constant_values=(float(padtype),float(padtype)))
     elif padtype.lower() == 'mean':
         # Pad with the mean
         ap = numpy.pad(a, nps, mode='mean')
     elif padtype.lower() == 'lintaper':
         # Linearly taper to the mean
-        ap = numpy.pad(a, nps, mode='linear_ramp', end_values=m)
+        ap = numpy.pad(a, nps, mode='linear_ramp', end_values=(m, m))
     elif padtype.lower() == 'edge':
         # Pad with edge values
         ap = numpy.pad(a, nps, mode='edge')

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -21,7 +21,7 @@ Create and operate on grids and profiles.
 
 * :func:`~fatiando.gridder.pad_array`
 * :func:`~fatiando.gridder.unpad_array`
-* :func:`~fatiando.gridder.padcoords`
+* :func:`~fatiando.gridder.pad_coords`
 
 **Input/Output**
 
@@ -471,8 +471,8 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
 
     Parameters:
 
-    * a : numpy array
-        numpy array (N-D) to be padded
+    * a : array
+        Array (N-D) to be padded
     * npd : tuple (optional)
         Desired shape of new padded array.  If not provided, the nearest
         power of 2 will be used.
@@ -504,6 +504,15 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
     * nps : list
         List of tuples containing the number of elements padded onto each
         dimension.
+
+    Examples:
+
+        >>> z = numpy.array([3, 4, 4, 5, 6])
+        >>> zpad, nps = pad_array(z)
+        >>> zpad
+        array([ 4.4,  3.2,  3. ,  4. ,  4. ,  5. ,  6. ,  4.4])
+        >>> nps
+        [(2, 1)]
 
     """
 
@@ -596,7 +605,7 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
 
 
 def unpad_array(a, nps):
-    '''
+    """
     Unpads an array using the outputs from pad_array.
 
     This function takes a padded array and removes the padding from both.
@@ -609,7 +618,7 @@ def unpad_array(a, nps):
 
     Parameters:
 
-    * a : N-D array
+    * a : array
         Array to be un-padded.  Can be of arbitrary dimension.
     * nps : list
         List of tuples giving the min and max indices for the cutoff.
@@ -617,10 +626,20 @@ def unpad_array(a, nps):
 
     Returns:
 
-    * b : N-D array
+    * b : array
         Array of same dimension as a, with padding removed
 
-    '''
+    Examples:
+
+        >>> z = numpy.array([3, 4, 4, 5, 6])
+        >>> zpad, nps = pad_array(z)
+        >>> zpad
+        array([ 4.4,  3.2,  3. ,  4. ,  4. ,  5. ,  6. ,  4.4])
+        >>> zunpad = unpad_array(zpad, nps)
+        >>> zunpad
+        array([ 3.,  4.,  4.,  5.,  6.])
+
+    """
     o = []
     for ii in range(0, a.ndim):
         o.append(slice(nps[ii][0], a.shape[ii] - nps[ii][1]))
@@ -629,8 +648,8 @@ def unpad_array(a, nps):
     return b
 
 
-def padcoords(xy, s, nps):
-    '''
+def pad_coords(xy, shape, nps):
+    """
     Pads coordinate vectors.
 
     Designed to be used in concert with :func:`~fatiando.gridder.pad_array`,
@@ -639,27 +658,45 @@ def padcoords(xy, s, nps):
 
     Parameters:
 
-    * xy : List
+    * xy : list
         List of arrays of coordinates
-    * s : tuple
-        Size of original array array
+    * shape : tuple
+        Size of original array
     * nps : tuple
         Size of padded array
 
     Returns:
 
-    * coordspad : List
+    * coordspad : list
         List of padded coordinate arrays
 
-    '''
+    Examples:
+
+        >>> shape = (5, 6)
+        >>> x, y, z = regular((-10,10,-20,0), shape, z=-25)
+        >>> gz = numpy.zeros(shape)
+        >>> gzpad, nps = pad_array(gz)
+        >>> x.reshape(shape)[:,0]
+        array([-10.,  -5.,   0.,   5.,  10.])
+        >>> y.reshape(shape)[0,:]
+        array([-20., -16., -12.,  -8.,  -4.,   0.])
+        # Pad the coordinate vectors
+        >>> xy = [x, y]
+        >>> [xp, yp] = pad_coords(xy, shape, nps)
+        >>> xp
+        array([-20., -15., -10.,  -5.,   0.,   5.,  10.,  15.])
+        >>> yp
+        array([-24., -20., -16., -12.,  -8.,  -4.,   0.,   4.])
+
+    """
     coords = []
     d = []
     coordspad = []
-    for ii in range(0, len(s)):
-        if type(xy) is numpy.ndarray:
+    for ii in range(0, len(shape)):
+        if type(xy) is not list:
             coords.append(xy)
-        elif type(xy) is list and len(s) > 1:
-            coords.append(xy[ii].reshape(s).transpose().take(0, axis=ii))
+        elif type(xy) is list and len(shape) > 1:
+            coords.append(xy[ii].reshape(shape).transpose().take(0, axis=ii))
         d.append(coords[ii][1] - coords[ii][0])
         coordspad.append(_padcvec(coords[ii], nps[ii], d[ii]))
 

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -477,10 +477,11 @@ def pad_array(a, npd=None, padtype='OddReflectionTaper'):
         Desired shape of new padded array.  If not provided, the nearest
         power of 2 will be used.
     * padtype : string (optional)
-        String describing what to pad the new values with. Options:
+        String describing with what to pad the new values. Options:
 
         [ oddreflectiontaper | oddreflection | reflection | value | lintaper
         | edge | mean ]
+
             oddreflectiontaper - Generates odd reflection then tapers to the
             mean using a cosine function (Default)
 
@@ -602,16 +603,16 @@ def unpad_array(a, nps):
     Effectively, this is a complement to gridder.cut for when you already
     know the number of elements to remove.
 
-    .. note: Unlike :func:`~fatiando.gridder.pad_array`, this returns a slice
-    of the input array.  Therefore, any changes to the padded array will be
-    reflected in the unpadded array.
+    .. note:: Unlike :func:`~fatiando.gridder.pad_array`, this returns a slice
+        of the input array.  Therefore, any changes to the padded array will be
+        reflected in the unpadded array.
 
     Parameters:
 
     * a : N-D array
         Array to be un-padded.  Can be of arbitrary dimension.
     * nps : list
-        List of tuples giving the min and max indices for the cutoff
+        List of tuples giving the min and max indices for the cutoff.
         Identical to nps returned by pad_array
 
     Returns:

--- a/fatiando/gridder.py
+++ b/fatiando/gridder.py
@@ -665,8 +665,8 @@ def pad_coords(xy, shape, nps):
     same discretization.
 
     .. note:: This function returns a list of arrays in the same format
-    as, for example, :func:`~fatiando.gridder.regular`.  It is a list of
-    flattened meshgrids for each vector in the same order as was input.
+        as, for example, :func:`~fatiando.gridder.regular`.  It is a list of
+        flattened meshgrids for each vector in the same order as was input.
 
     Parameters:
 
@@ -684,8 +684,6 @@ def pad_coords(xy, shape, nps):
         List of padded coordinate arrays
 
     Examples:
-
-    Construct padded arrays
 
         >>> shape = (5, 6)
         >>> x, y, z = regular((-10,10,-20,0), shape, z=-25)

--- a/test/test_gridder_padarray.py
+++ b/test/test_gridder_padarray.py
@@ -1,83 +1,89 @@
 import numpy as np
-from fatiando import mesher,gridder
+from fatiando import mesher, gridder
 from fatiando.gravmag import prism
 from numpy.testing import assert_array_almost_equal as assert_almost
 from nose.tools import assert_raises
 from nose.tools import assert_equal
 
+
 def test_fails_if_bad_pad_operation():
     'gridder.pad_array fails if given a bad padding array operation option'
     p = 'foo'
-    s = (100,100)
-    x,y,z = gridder.regular((-1000.,1000.,-1000.,1000.),s,z=-150)
+    s = (100, 100)
+    x, y, z = gridder.regular((-1000., 1000., -1000., 1000.), s, z=-150)
     g = z.reshape(s)
-    assert_raises(ValueError,gridder.pad_array,g,padtype=p)
+    assert_raises(ValueError, gridder.pad_array, g, padtype=p)
+
 
 def test_pad_and_unpad_equal_2d():
     'gridder.pad_array and subsequent .unpad_array gives original array: 2D'
-    s = (100,101)
-    x,y,z = gridder.regular((-5000.,5000.,-5000.,5000.),s,z=-150)
-    model = [mesher.Prism(-4000,-3000,-4000,-3000,0,2000,{'density':1000}),
-        mesher.Prism(-1000,1000,-1000,1000,0,2000,{'density':-900}),
-        mesher.Prism(2000,4000,3000,4000,0,2000,{'density':1300})]
-    gz = prism.gz(x,y,z,model)
+    s = (100, 101)
+    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), s, z=-150)
+    model = [mesher.Prism(-4000, -3000, -4000, -3000, 0, 2000,
+            {'density': 1000}), mesher.Prism(-1000, 1000, -1000, 1000, 0, 2000,
+            {'density': -900}), mesher.Prism(2000, 4000, 3000, 4000, 0, 2000,
+            {'density': 1300})]
+    # rosenbrock: (a-x)^2 + b(y-x^2)^2  a=1 b=100 usually
+    gz = prism.gz(x, y, z, model)
     gz = gz.reshape(s)
-    gpad,_,nps = gridder.pad_array(gz)
-    gunpad = gridder.unpad_array(gpad,nps)
-    assert_almost(gunpad,gz)
+    gpad, nps = gridder.pad_array(gz)
+    gunpad = gridder.unpad_array(gpad, nps)
+    assert_almost(gunpad, gz)
+
 
 def test_pad_and_unpad_equal_1d():
     'gridder.pad_array and subsequent .unpad_array gives original array: 1D'
     x = np.random.rand(21)
-    xpad, _, nps = gridder.pad_array(x)
+    xpad, nps = gridder.pad_array(x)
     xunpad = gridder.unpad_array(xpad, nps)
     assert_almost(xunpad, x)
 
+
 def test_coordinatevec_padding_1d():
-    'gridder.pad_array accurately pads coordinate vector in 1D'
+    'gridder.padcoords accurately pads coordinate vector in 1D'
     f = np.random.rand(72) * 10
     x = np.arange(100, 172)
-    fpad, xpad, nps = gridder.pad_array(f, xy=x)
-    assert_almost(xpad[0][nps[0][0]:-nps[0][1]],x)
+    fpad, nps = gridder.pad_array(f)
+    xpad = gridder.padcoords(x, f.shape, nps)
+    assert_almost(xpad[0][nps[0][0]:-nps[0][1]], x)
+
 
 def test_coordinatevec_padding_2d():
-    'gridder.pad_array accurately pads coordinate vector in 2D'
-    s = (101,172)
-    x,y,z = gridder.regular((-5000.,5000.,-5000.,5000.),s,z=-150)
-    model = [mesher.Prism(-4000,-3000,-4000,-3000,0,2000,{'density':1000}),
-        mesher.Prism(-1000,1000,-1000,1000,0,2000,{'density':-900}),
-        mesher.Prism(2000,4000,3000,4000,0,2000,{'density':1300})]
-    gz = prism.gz(x,y,z,model)
-    gz = gz.reshape(s)
-    xy = np.zeros((len(x),2))
-    xy[:,0] = x[:]
-    xy[:,1] = y[:]
-    gpad,xyp,nps = gridder.pad_array(gz,xy=xy)
-    [Yp,Xp] = np.meshgrid(xyp[1],xyp[0])
-    assert_equal(Yp.shape,gpad.shape)
-    assert_almost(Yp[nps[0][0]:-nps[0][1],nps[1][0]:-nps[1][1]].ravel(),y)
-    assert_almost(Xp[nps[0][0]:-nps[0][1],nps[1][0]:-nps[1][1]].ravel(),x)
+    'gridder.padcoords accurately pads coordinate vector in 2D'
+    s = (101, 172)
+    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), s, z=-150)
+    gz = np.zeros(s)
+    xy = []
+    xy.append(x)
+    xy.append(y)
+    gpad, nps = gridder.pad_array(gz)
+    xyp = gridder.padcoords(xy, gz.shape, nps)
+    [Yp, Xp] = np.meshgrid(xyp[1], xyp[0])
+    assert_equal(Yp.shape, gpad.shape)
+    assert_almost(Yp[nps[0][0]:-nps[0][1], nps[1][0]:-nps[1][1]].ravel(), y)
+    assert_almost(Xp[nps[0][0]:-nps[0][1], nps[1][0]:-nps[1][1]].ravel(), x)
+
 
 def test_fails_if_npd_incorrect_dimension():
     'gridder.pad_array raises error if given improper dimension on npadding'
-    s = (101,172)
-    x,y,z = gridder.regular((-5000.,5000.,-5000.,5000.),s,z=-150)
+    s = (101, 172)
+    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), s, z=-150)
     g = z.reshape(s)
     npdt = 128
-    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
-    npdt = (128,256,142)
-    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
+    assert_raises(ValueError, gridder.pad_array, g, npd=npdt)
+    npdt = (128, 256, 142)
+    assert_raises(ValueError, gridder.pad_array, g, npd=npdt)
     g = np.random.rand(50)
-    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
+    assert_raises(ValueError, gridder.pad_array, g, npd=npdt)
+
 
 def test_fails_if_npd_lessthan_arraydim():
     'gridder.pad_array raises error if given npad is less than array length'
-    s = (101,172)
-    x,y,z = gridder.regular((-5000.,5000.,-5000.,5000.),s,z=-150)
+    s = (101, 172)
+    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), s, z=-150)
     g = z.reshape(s)
-    npdt = (128,128)
-    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
+    npdt = (128, 128)
+    assert_raises(ValueError, gridder.pad_array, g, npd=npdt)
     g = np.random.rand(20)
     npdt = 16
-    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
-    
+    assert_raises(ValueError, gridder.pad_array, g, npd=npdt)

--- a/test/test_gridder_padarray.py
+++ b/test/test_gridder_padarray.py
@@ -1,0 +1,83 @@
+import numpy as np
+from fatiando import mesher,gridder
+from fatiando.gravmag import prism
+from numpy.testing import assert_array_almost_equal as assert_almost
+from nose.tools import assert_raises
+from nose.tools import assert_equal
+
+def test_fails_if_bad_pad_operation():
+    'gridder.pad_array fails if given a bad padding array operation option'
+    p = 'foo'
+    s = (100,100)
+    x,y,z = gridder.regular((-1000.,1000.,-1000.,1000.),s,z=-150)
+    g = z.reshape(s)
+    assert_raises(ValueError,gridder.pad_array,g,padtype=p)
+
+def test_pad_and_unpad_equal_2d():
+    'gridder.pad_array and subsequent .unpad_array gives original array: 2D'
+    s = (100,101)
+    x,y,z = gridder.regular((-5000.,5000.,-5000.,5000.),s,z=-150)
+    model = [mesher.Prism(-4000,-3000,-4000,-3000,0,2000,{'density':1000}),
+        mesher.Prism(-1000,1000,-1000,1000,0,2000,{'density':-900}),
+        mesher.Prism(2000,4000,3000,4000,0,2000,{'density':1300})]
+    gz = prism.gz(x,y,z,model)
+    gz = gz.reshape(s)
+    gpad,_,nps = gridder.pad_array(gz)
+    gunpad = gridder.unpad_array(gpad,nps)
+    assert_almost(gunpad,gz)
+
+def test_pad_and_unpad_equal_1d():
+    'gridder.pad_array and subsequent .unpad_array gives original array: 1D'
+    x = np.random.rand(21)
+    xpad, _, nps = gridder.pad_array(x)
+    xunpad = gridder.unpad_array(xpad, nps)
+    assert_almost(xunpad, x)
+
+def test_coordinatevec_padding_1d():
+    'gridder.pad_array accurately pads coordinate vector in 1D'
+    f = np.random.rand(72) * 10
+    x = np.arange(100, 172)
+    fpad, xpad, nps = gridder.pad_array(f, xy=x)
+    assert_almost(xpad[0][nps[0][0]:-nps[0][1]],x)
+
+def test_coordinatevec_padding_2d():
+    'gridder.pad_array accurately pads coordinate vector in 2D'
+    s = (101,172)
+    x,y,z = gridder.regular((-5000.,5000.,-5000.,5000.),s,z=-150)
+    model = [mesher.Prism(-4000,-3000,-4000,-3000,0,2000,{'density':1000}),
+        mesher.Prism(-1000,1000,-1000,1000,0,2000,{'density':-900}),
+        mesher.Prism(2000,4000,3000,4000,0,2000,{'density':1300})]
+    gz = prism.gz(x,y,z,model)
+    gz = gz.reshape(s)
+    xy = np.zeros((len(x),2))
+    xy[:,0] = x[:]
+    xy[:,1] = y[:]
+    gpad,xyp,nps = gridder.pad_array(gz,xy=xy)
+    [Yp,Xp] = np.meshgrid(xyp[1],xyp[0])
+    assert_equal(Yp.shape,gpad.shape)
+    assert_almost(Yp[nps[0][0]:-nps[0][1],nps[1][0]:-nps[1][1]].ravel(),y)
+    assert_almost(Xp[nps[0][0]:-nps[0][1],nps[1][0]:-nps[1][1]].ravel(),x)
+
+def test_fails_if_npd_incorrect_dimension():
+    'gridder.pad_array raises error if given improper dimension on npadding'
+    s = (101,172)
+    x,y,z = gridder.regular((-5000.,5000.,-5000.,5000.),s,z=-150)
+    g = z.reshape(s)
+    npdt = 128
+    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
+    npdt = (128,256,142)
+    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
+    g = np.random.rand(50)
+    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
+
+def test_fails_if_npd_lessthan_arraydim():
+    'gridder.pad_array raises error if given npad is less than array length'
+    s = (101,172)
+    x,y,z = gridder.regular((-5000.,5000.,-5000.,5000.),s,z=-150)
+    g = z.reshape(s)
+    npdt = (128,128)
+    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
+    g = np.random.rand(20)
+    npdt = 16
+    assert_raises(ValueError,gridder.pad_array,g,npd=npdt)
+    

--- a/test/test_gridder_padarray.py
+++ b/test/test_gridder_padarray.py
@@ -24,12 +24,12 @@ def test_pad_and_unpad_equal_2d():
     # rosenbrock: (a-x)^2 + b(y-x^2)^2  a=1 b=100 usually
     X = x.reshape(s)
     Y = y.reshape(s)
-    xy = [x,y]
-    gz = scipy.optimize.rosen([Y/100000.,X/100000.])
-    pads = ['mean', 'edge', 'lintaper', 'reflection', 'oddreflection', 
+    xy = [x, y]
+    gz = scipy.optimize.rosen([Y/100000., X/100000.])
+    pads = ['mean', 'edge', 'lintaper', 'reflection', 'oddreflection',
             'oddreflectiontaper', '0']
     for p in pads:
-        gpad, nps = gridder.pad_array(gz,padtype=p)
+        gpad, nps = gridder.pad_array(gz, padtype=p)
         gunpad = gridder.unpad_array(gpad, nps)
         assert_almost(gunpad, gz)
 

--- a/test/test_gridder_padarray.py
+++ b/test/test_gridder_padarray.py
@@ -11,19 +11,19 @@ from numpy.random import RandomState
 def test_fails_if_bad_pad_operation():
     'gridder.pad_array fails if given a bad padding array operation option'
     p = 'foo'
-    s = (100, 100)
-    x, y, z = gridder.regular((-1000., 1000., -1000., 1000.), s, z=-150)
-    g = z.reshape(s)
+    shape = (100, 100)
+    x, y, z = gridder.regular((-1000., 1000., -1000., 1000.), shape, z=-150)
+    g = z.reshape(shape)
     assert_raises(ValueError, gridder.pad_array, g, padtype=p)
 
 
 def test_pad_and_unpad_equal_2d():
     'gridder.pad_array and subsequent .unpad_array gives original array: 2D'
-    s = (100, 101)
-    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), s, z=-150)
+    shape = (100, 101)
+    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), shape, z=-150)
     # rosenbrock: (a-x)^2 + b(y-x^2)^2  a=1 b=100 usually
-    X = x.reshape(s)
-    Y = y.reshape(s)
+    X = x.reshape(shape)
+    Y = y.reshape(shape)
     xy = [x, y]
     gz = scipy.optimize.rosen([Y/100000., X/100000.])
     pads = ['mean', 'edge', 'lintaper', 'reflection', 'oddreflection',
@@ -49,20 +49,20 @@ def test_coordinatevec_padding_1d():
     f = prng.rand(72) * 10
     x = np.arange(100, 172)
     fpad, nps = gridder.pad_array(f)
-    xpad = gridder.padcoords(x, f.shape, nps)
+    xpad = gridder.pad_coords(x, f.shape, nps)
     assert_almost(xpad[0][nps[0][0]:-nps[0][1]], x)
 
 
 def test_coordinatevec_padding_2d():
     'gridder.padcoords accurately pads coordinate vector in 2D'
-    s = (101, 172)
-    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), s, z=-150)
-    gz = np.zeros(s)
+    shape = (101, 172)
+    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), shape, z=-150)
+    gz = np.zeros(shape)
     xy = []
     xy.append(x)
     xy.append(y)
     gpad, nps = gridder.pad_array(gz)
-    xyp = gridder.padcoords(xy, gz.shape, nps)
+    xyp = gridder.pad_coords(xy, gz.shape, nps)
     [Yp, Xp] = np.meshgrid(xyp[1], xyp[0])
     assert_equal(Yp.shape, gpad.shape)
     assert_almost(Yp[nps[0][0]:-nps[0][1], nps[1][0]:-nps[1][1]].ravel(), y)
@@ -85,9 +85,9 @@ def test_fails_if_npd_incorrect_dimension():
 
 def test_fails_if_npd_lessthan_arraydim():
     'gridder.pad_array raises error if given npad is less than array length'
-    s = (101, 172)
-    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), s, z=-150)
-    g = z.reshape(s)
+    shape = (101, 172)
+    x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), shape, z=-150)
+    g = z.reshape(shape)
     npdt = (128, 128)
     assert_raises(ValueError, gridder.pad_array, g, npd=npdt)
     prng = RandomState(12345)

--- a/test/test_gridder_padarray.py
+++ b/test/test_gridder_padarray.py
@@ -4,6 +4,8 @@ from fatiando.gravmag import prism
 from numpy.testing import assert_array_almost_equal as assert_almost
 from nose.tools import assert_raises
 from nose.tools import assert_equal
+import scipy.optimize
+from numpy.random import RandomState
 
 
 def test_fails_if_bad_pad_operation():
@@ -19,21 +21,23 @@ def test_pad_and_unpad_equal_2d():
     'gridder.pad_array and subsequent .unpad_array gives original array: 2D'
     s = (100, 101)
     x, y, z = gridder.regular((-5000., 5000., -5000., 5000.), s, z=-150)
-    model = [mesher.Prism(-4000, -3000, -4000, -3000, 0, 2000,
-            {'density': 1000}), mesher.Prism(-1000, 1000, -1000, 1000, 0, 2000,
-            {'density': -900}), mesher.Prism(2000, 4000, 3000, 4000, 0, 2000,
-            {'density': 1300})]
     # rosenbrock: (a-x)^2 + b(y-x^2)^2  a=1 b=100 usually
-    gz = prism.gz(x, y, z, model)
-    gz = gz.reshape(s)
-    gpad, nps = gridder.pad_array(gz)
-    gunpad = gridder.unpad_array(gpad, nps)
-    assert_almost(gunpad, gz)
+    X = x.reshape(s)
+    Y = y.reshape(s)
+    xy = [x,y]
+    gz = scipy.optimize.rosen([Y/100000.,X/100000.])
+    pads = ['mean', 'edge', 'lintaper', 'reflection', 'oddreflection', 
+            'oddreflectiontaper', '0']
+    for p in pads:
+        gpad, nps = gridder.pad_array(gz,padtype=p)
+        gunpad = gridder.unpad_array(gpad, nps)
+        assert_almost(gunpad, gz)
 
 
 def test_pad_and_unpad_equal_1d():
     'gridder.pad_array and subsequent .unpad_array gives original array: 1D'
-    x = np.random.rand(21)
+    prng = RandomState(12345)
+    x = prng.rand(21)
     xpad, nps = gridder.pad_array(x)
     xunpad = gridder.unpad_array(xpad, nps)
     assert_almost(xunpad, x)
@@ -41,7 +45,8 @@ def test_pad_and_unpad_equal_1d():
 
 def test_coordinatevec_padding_1d():
     'gridder.padcoords accurately pads coordinate vector in 1D'
-    f = np.random.rand(72) * 10
+    prng = RandomState(12345)
+    f = prng.rand(72) * 10
     x = np.arange(100, 172)
     fpad, nps = gridder.pad_array(f)
     xpad = gridder.padcoords(x, f.shape, nps)
@@ -73,7 +78,8 @@ def test_fails_if_npd_incorrect_dimension():
     assert_raises(ValueError, gridder.pad_array, g, npd=npdt)
     npdt = (128, 256, 142)
     assert_raises(ValueError, gridder.pad_array, g, npd=npdt)
-    g = np.random.rand(50)
+    prng = RandomState(12345)
+    g = prng.rand(50)
     assert_raises(ValueError, gridder.pad_array, g, npd=npdt)
 
 
@@ -84,6 +90,7 @@ def test_fails_if_npd_lessthan_arraydim():
     g = z.reshape(s)
     npdt = (128, 128)
     assert_raises(ValueError, gridder.pad_array, g, npd=npdt)
-    g = np.random.rand(20)
+    prng = RandomState(12345)
+    g = prng.rand(20)
     npdt = 16
     assert_raises(ValueError, gridder.pad_array, g, npd=npdt)

--- a/test/test_gridder_padarray.py
+++ b/test/test_gridder_padarray.py
@@ -49,8 +49,8 @@ def test_coordinatevec_padding_1d():
     f = prng.rand(72) * 10
     x = np.arange(100, 172)
     fpad, nps = gridder.pad_array(f)
-    xpad = gridder.pad_coords(x, f.shape, nps)
-    assert_almost(xpad[0][nps[0][0]:-nps[0][1]], x)
+    N = gridder.pad_coords(x, f.shape, nps)
+    assert_almost(N[0][nps[0][0]:-nps[0][1]], x)
 
 
 def test_coordinatevec_padding_2d():
@@ -62,9 +62,10 @@ def test_coordinatevec_padding_2d():
     xy.append(x)
     xy.append(y)
     gpad, nps = gridder.pad_array(gz)
-    xyp = gridder.pad_coords(xy, gz.shape, nps)
-    [Yp, Xp] = np.meshgrid(xyp[1], xyp[0])
-    assert_equal(Yp.shape, gpad.shape)
+    N = gridder.pad_coords(xy, gz.shape, nps)
+    Yp = N[1].reshape(gpad.shape)
+    Xp = N[0].reshape(gpad.shape)
+    assert_equal(N[0].reshape(gpad.shape).shape, gpad.shape)
     assert_almost(Yp[nps[0][0]:-nps[0][1], nps[1][0]:-nps[1][1]].ravel(), y)
     assert_almost(Xp[nps[0][0]:-nps[0][1], nps[1][0]:-nps[1][1]].ravel(), x)
 


### PR DESCRIPTION
This is an incomplete pull request for the addition of array padding and unpadding routines to gridder.

Some talking points:
--The padding function expects the array to be of the same dimension as intended--that is, no 'flattened' arrays.
--The unpadding function currently is set up to return unpadded coordinate vectors.  However, I think that may be completely unnecessary.
--Still working on cleaning up the docs, the actual code, and need to create the test functions.

Update 03-12-2015 (@leouieda): Added the checklist below.

## Checklist:

- [x] Make tests for new code
- [x] Create/update docstrings
- [x] Include relevant equations and citations in docstrings
- [x] Code follows PEP8 style conventions
- [x] Code and docs have been spellchecked
- [x] Include new dependencies in docs, requirements.txt, README, and .travis.yml
- [x] Documentation builds properly
- [x] All tests pass
- [x] Can be merged
- [x] Changelog entry (leave for last)
- [x] Firt-time contributor? Add yourself to `doc/contributors.rst` (leave for last)
