### PR TITLE
Print result in center_of_mass test

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,8 @@ Version (development)
 
 **Changes**:
 
+* Fix the doctest for ``fatiando.gravmag.tensor.center_of_mass``.
+  (`PR 242 <https://github.com/fatiando/fatiando/pull/242>`__)
 * **BUG FIX**: Tesseroid computations failed (silently) when tesseroids were
   smaller than 1e-6 degrees on a side (~ 10 cm). Code now ignores these
   tesseroids on input and warns the user about it. If a tesseroid becomes

--- a/fatiando/gravmag/tensor.py
+++ b/fatiando/gravmag/tensor.py
@@ -186,8 +186,8 @@ def center_of_mass(x, y, z, eigvec1, windows=1, wcenter=None, wmin=None,
     >>> eigenvals, eigenvecs = tensor.eigen(data)
     >>> # Now estimate the center of mass
     >>> cm = tensor.center_of_mass(x, y, z, eigenvecs[0])
-    >>> cm
-    array([-100.,  20., 100.])
+    >>> print('{:.1f} {:.1f} {:.1f}'.format(cm[0], cm[1], cm[2]))
+    -100.0 20.0 100.0
 
     """
     if wmin is None:


### PR DESCRIPTION
The doctest in fatiando.gravmag.tensor.center_of_mass was checking the
result (a numpy array) without printing it with a given precision. This
was causing the test to fail unpredictably in different computers.

The test now prints the result with `.1f`. This should fix the failures.

Fixes #241

## Checklist:

- [x] Make tests for new code
- [x] Create/update docstrings
- [x] Include relevant equations and citations in docstrings
- [x] Code follows PEP8 style conventions
- [x] Code and docs have been spellchecked
- [x] Include new dependencies in docs, requirements.txt, README, and .travis.yml
- [x] Documentation builds properly
- [x] All tests pass
- [x] Can be merged
- [x] Changelog entry (leave for last)