### PR TITLE
Print the Fatiando version on Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,13 @@ env:
   matrix:
     - PYTHON=2.7
 
+before_install:
+  # Need to fetch a deeper clone because the default depth Travis uses (50)
+  # isn't enough to get the git tags so versioneer can't find the correct
+  # version number.
+  - git fetch --depth=100
+
 install:
-  - git describe --tags --dirty --always
   # Get Miniconda from Continuum
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
   - conda list
   - pip install .
   - python setup.py build_ext --inplace
+  - python -c "import fatiando; print(fatiando.__version__)"
 
 script:
   - nosetests -v --with-doctest --with-coverage --cover-package=fatiando fatiando test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,14 @@ env:
   matrix:
     - PYTHON=2.7
 
-before_install:
+install:
   # Get Miniconda from Continuum
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda2/bin:$PATH
   - cp ci-tools/matplotlibrc .
-
-install:
+  # Create a conda env to install required libraries
   - conda update --yes conda
   - conda create -n testenv --yes pip python=$PYTHON
   - conda update conda --yes
@@ -28,10 +27,14 @@ install:
   - conda install --yes --file requirements.txt
   - conda install --yes --file test/requirements-conda.txt
   - pip install -r test/requirements-pip.txt
+  # Show installed pkg information for postmortem diagnostic
   - conda list
-  - pip install .
-  - python setup.py build_ext --inplace
+  # Package Fatiando and install
+  - python setup.py sdist  --formats=gztar
+  - pip install dist/fatiando-*.tar.gz
+  # Check that versioneer got the correct version
   - python -c "import fatiando; print(fatiando.__version__)"
+  - python setup.py build_ext --inplace
 
 script:
   - nosetests -v --with-doctest --with-coverage --cover-package=fatiando fatiando test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - PYTHON=2.7
 
 install:
+  - git describe --tags --dirty --always
   # Get Miniconda from Continuum
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh


### PR DESCRIPTION
Tweaks to the Travis build:

* Print the version of Fatiando detected by versioneer
* Build a source package using `setup.py` and install that using `pip`
* git fetch with a larger depth to include the tags (the default clone of Travis was too shallow and versioneer could not get the proper version string)