### PR TITLE
Fix small docs issues for 0.4

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -1,52 +1,47 @@
 Citing
 ======
 
-Fatiando is **made by scientists**.
-Citations help us justify the effort
-that goes into building and maintaining Fatiando.
+Fatiando is **made by scientists**.  Citations help us justify the effort that
+goes into building and maintaining Fatiando.
 
 Citing the software
 -------------------
 
-If you use it in your research, please cite software archive on
-`figshare <http://figshare.com/>`__ in your publications as:
+If you use it in your research, please cite Fatiando in your publications as:
 
-    Uieda, L, Oliveira Jr, V C, Ferreira, A, Santos, H B; Caparica Jr, J F (2014),
-    Fatiando a Terra: a Python package for modeling and inversion in geophysics.
-    figshare. doi:10.6084/m9.figshare.1115194
+    Uieda, L., V. C. Oliveira Jr, and V. C. F. Barbosa (2013), Modeling the
+    Earth with Fatiando a Terra, Proceedings of the 12th Python in Science
+    Conference, pp. 91 - 98.
 
-See http://dx.doi.org/10.6084/m9.figshare.1115194 for more citation styles,
-BibTeX files, etc.
+This article was `peer-reviewed
+<https://github.com/scipy-conference/scipy_proceedings/pull/52>`__ and is
+available open-access at the `conference website
+<http://conference.scipy.org/proceedings/scipy2013/uieda.html>`__.
+Source files and extra material for the paper are on the
+`leouieda/scipy2013 <https://github.com/leouieda/scipy2013>`__ Github
+repository.
+
+Here is a Bibtex entry for LaTeX users::
+
+    @InProceedings{ uieda-proc-scipy-2013,
+      author    = { Leonardo Uieda and Vanderlei C. Oliveira Jr and Val\'eria C. F. Barbosa },
+      title     = { Modeling the Earth with Fatiando a Terra },
+      booktitle = { Proceedings of the 12th Python in Science Conference },
+      pages     = { 96 - 103 },
+      year      = { 2013 },
+      editor    = { St\'efan van der Walt and Jarrod Millman and Katy Huff }
+    }
+
 
 Citing the methods
 ------------------
 
-Some of the methods implemented here are also **original research** by
-the developers.
-If you used any of the code below, please **also cite the method papers**.
+Please also cite the method papers of individual functions and classes. The
+proper references are found in the function, class or module documentation.
 
-Polynomial Equivalent Layer
-+++++++++++++++++++++++++++
-
-Implemented in ``fatiando.gravmag.eqlayer.PELGravity`` and
-``fatiando.gravmag.eqlayer.PELTotalField``.
+For example,  the ``fatiando.gravmag.eqlayer.PELGravity`` and
+``fatiando.gravmag.eqlayer.PELTotalField`` classes implement:
 
     Oliveira Jr, V. C., V. C. F. Barbosa, and L. Uieda (2013), Polynomial
     equivalent layer, Geophysics, 78(1), G1-G13, doi:10.1190/geo2012-0196.1.
 
-Published article: http://library.seg.org/doi/abs/10.1190/geo2012-0196.1
-<`pdf
-<http://www.leouieda.com/pdf/paper-polynomial-eqlayer-2013.pdf>`__>
-
-3D potential-field inversion by a planting algorithm
-++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-Implemented in ``fatiando.gravmag.harvester``.
-
-    Uieda, L., and V. C. F. Barbosa (2012), Robust 3D gravity gradient inversion by
-    planting anomalous densities, Geophysics, 77(4), G55-G66,
-    doi:10.1190/geo2011-0388.1
-
-Published article: http://library.seg.org/doi/abs/10.1190/geo2011-0388.1
-<`pdf
-<http://www.leouieda.com/pdf/paper-planting-anomalous-densities-2012.pdf>`__>

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,6 @@
 
 An open-source Python library for modeling and inversion in geophysics.
 
-Our goal is provide a comprehensive and extensible framework
-for geophysical data analysis and the development of new methodologies.
-
 .. image:: http://img.shields.io/pypi/v/fatiando.svg?style=flat-square
     :alt: Latest PyPI version
     :target: https://crate.io/packages/fatiando
@@ -31,6 +28,12 @@ for geophysical data analysis and the development of new methodologies.
 .. image:: http://img.shields.io/badge/GITTER-JOIN_CHAT-brightgreen.svg?style=flat-square
     :alt: gitter chat room at https://gitter.im/fatiando/fatiando
     :target: https://gitter.im/fatiando/fatiando
+
+Overview
+--------
+
+Our goal is provide a comprehensive and extensible framework
+for geophysical data analysis and the development of new methodologies.
 
 **Research:** Fatiando allows you to write Python scripts to
 perform your data analysis and generate figures in a reproducible way.

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,13 @@
     :alt: Fatiando a Terra
 
 `Website <http://www.fatiando.org>`__ |
-`Docs <http://fatiando.github.io/docs.html>`__ |
-`Mailing list <https://groups.google.com/d/forum/fatiando>`__ |
-`Google+ <https://plus.google.com/+FatiandoOrg>`__
+`Docs <http://www.fatiando.org/docs.html>`__ |
+`Mailing list <https://groups.google.com/d/forum/fatiando>`__
 
-A Python package for modeling and inversion in geophysics.
+An open-source Python library for modeling and inversion in geophysics.
+
+Our goal is provide a comprehensive and extensible framework
+for geophysical data analysis and the development of new methodologies.
 
 .. image:: http://img.shields.io/pypi/v/fatiando.svg?style=flat-square
     :alt: Latest PyPI version
@@ -30,22 +32,33 @@ A Python package for modeling and inversion in geophysics.
     :alt: gitter chat room at https://gitter.im/fatiando/fatiando
     :target: https://gitter.im/fatiando/fatiando
 
+**Research:** Fatiando allows you to write Python scripts to
+perform your data analysis and generate figures in a reproducible way.
+
+**Development:** Designed for extensibility, Fatiando offers tools for users to
+build upon the existing infrastructure and develop new inversion methods.
+We take care of the boilerplate.
+
+**Teaching:** Fatiando can be combined with the `Jupyter notebook
+<https://jupyter.org/>`__ to make rich, interactive documents. Great for
+teaching fundamental concepts of geophysics.
+
+Getting started
+---------------
+
+Take a look at the `Documentation <http://www.fatiando.org/docs.html>`__ for a
+detailed tour of the library.  You can also browse the `Cookbook
+<http://www.fatiando.org/cookbook.html>`__ for examples of what Fatiando can
+do.
+
 Dependencies
 ------------
 
-For the moment, Fatiando runs and is tested in Python 2.7.
-To install and run Fatiando, you'll need the following packages:
-
-* numpy >= 1.8
-* scipy >= 0.14
-* matplotlib >= 1.3
-* IPython >= 2.0.0
-* mayavi >= 4.3
-* PIL >= 1.1.7
-* basemap >= 1.0.7
-* gcc >= 4.8.2
-* numba >= 0.17
-* future
+For the moment, Fatiando runs and is tested in **Python 2.7**.
+To install and run Fatiando, you'll need the following Python packages:
+``numpy``, ``scipy``, ``matplotlib``, ``ipython``, ``pillow``,
+``basemap``, ``numba``, ``future``, ``mayavi``.
+You'll also need a C compiler, preferably ``gcc``.
 
 You can get all of these on Linux, Mac, and Windows through
 the `Anaconda distribution <http://continuum.io/downloads>`__.
@@ -63,12 +76,12 @@ or get the latest development version from Github::
 
     pip install --upgrade https://github.com/fatiando/fatiando/archive/master.zip
 
-**Note**: ``fatiando.__version__`` has the current version number. If you install
-from PyPI, this will be something like ``'0.2'``. If you installed from Github,
-this will be the latest commit hash. This way you can track exactly what
-version of Fatiando generated your results.
+**Note**: ``fatiando.__version__`` has the current version number. If you
+install from PyPI, this will be something like ``'0.2'``. If you installed from
+Github, this will be the latest commit hash. This way you can track exactly
+what version of Fatiando generated your results.
 
-See the `documentation <http://fatiando.github.io/docs.html>`__ for detailed
+See the `documentation <http://www.fatiando.org/docs.html>`__ for detailed
 instructions.
 
 Citing
@@ -82,12 +95,10 @@ please **cite it** in your publications as::
     figshare. doi: 10.6084/m9.figshare.1115194
 
 Some of the methods implemented here are also **original research** by some of
-the developers. Please **also cite the method papers**.
-References are available in the documentation of each module.
-See the
-`CITATION.rst <https://github.com/fatiando/fatiando/blob/master/CITATION.rst>`__
-file or the `documentation <http://fatiando.github.io/cite.html>`__
-for more information.
+the developers. Please **also cite the method papers**.  References are
+available in the documentation of each module.  See the `CITATION.rst
+<https://github.com/fatiando/fatiando/blob/master/CITATION.rst>`__ file or the
+`documentation <http://www.fatiando.org/cite.html>`__ for more information.
 
 Read `this blog post by Robin Wilson
 <http://www.software.ac.uk/blog/2013-09-02-encouraging-citation-software-introducing-citation-files>`__
@@ -99,12 +110,12 @@ Getting help
 Here are a few option to get in touch with us:
 
 * `Open an issue on Github <https://github.com/fatiando/fatiando/issues>`__
-* `Ask on the Gitter chat room <https://gitter.im/fatiando/fatiando>`__
 * `Write to the mailing list <https://groups.google.com/d/forum/fatiando>`__
+* `Ask on the Gitter chat room <https://gitter.im/fatiando/fatiando>`__
 
 License
 -------
 
 Fatiando a Terra is free software: you can redistribute it and/or modify it
-under the terms of the **BSD 3-clause License**. A copy of this license is provided in
-`LICENSE.txt`.
+under the terms of the **BSD 3-clause License**. A copy of this license is
+provided in `LICENSE.txt`.

--- a/README.rst
+++ b/README.rst
@@ -90,18 +90,19 @@ instructions.
 Citing
 ------
 
-Fatiando is research software. If you use it in your research,
-please **cite it** in your publications as::
+If you use it in your research, please cite Fatiando in your publications as:
 
-    Uieda, L, Oliveira Jr, V C, Ferreira, A, Santos, H B; Caparica Jr, J F (2014),
-    Fatiando a Terra: a Python package for modeling and inversion in geophysics.
-    figshare. doi: 10.6084/m9.figshare.1115194
+    Uieda, L., V. C. Oliveira Jr, and V. C. F. Barbosa (2013), Modeling the
+    Earth with Fatiando a Terra, Proceedings of the 12th Python in Science
+    Conference, pp. 91 - 98.
 
-Some of the methods implemented here are also **original research** by some of
-the developers. Please **also cite the method papers**.  References are
-available in the documentation of each module.  See the `CITATION.rst
+Please **also cite the method papers** of individual functions/classes.
+References are available in the documentation of each module.
+
+See the `CITATION.rst
 <https://github.com/fatiando/fatiando/blob/master/CITATION.rst>`__ file or the
-`documentation <http://www.fatiando.org/cite.html>`__ for more information.
+`Citing section <http://www.fatiando.org/cite.html>`__ of the docs for more
+information.
 
 Read `this blog post by Robin Wilson
 <http://www.software.ac.uk/blog/2013-09-02-encouraging-citation-software-introducing-citation-files>`__

--- a/doc/cite.rst
+++ b/doc/cite.rst
@@ -3,52 +3,47 @@
 Citing
 ======
 
-Fatiando is research software **made by scientists**.
-Citations help us justify the effort
-that goes into building and maintaining Fatiando.
+Fatiando is **made by scientists**.  Citations help us justify the effort that
+goes into building and maintaining Fatiando.
 
 Citing the software
 -------------------
 
-If you use it in your research, please cite software archive on
-`figshare <http://figshare.com/>`__ in your publications as:
+If you use it in your research, please cite Fatiando in your publications as:
 
-    Uieda, L, Oliveira Jr, V C, Ferreira, A, Santos, H B; Caparica Jr, J F (2014),
-    Fatiando a Terra: a Python package for modeling and inversion in geophysics.
-    figshare. doi:10.6084/m9.figshare.1115194
+    Uieda, L., V. C. Oliveira Jr, and V. C. F. Barbosa (2013), Modeling the
+    Earth with Fatiando a Terra, Proceedings of the 12th Python in Science
+    Conference, pp. 91 - 98.
 
-See http://dx.doi.org/10.6084/m9.figshare.1115194 for more citation styles,
-BibTeX files, etc.
+This article was `peer-reviewed
+<https://github.com/scipy-conference/scipy_proceedings/pull/52>`__ and is
+available open-access at the `conference website
+<http://conference.scipy.org/proceedings/scipy2013/uieda.html>`__.
+Source files and extra material for the paper are on the
+`leouieda/scipy2013 <https://github.com/leouieda/scipy2013>`__ Github
+repository.
+
+Here is a Bibtex entry for LaTeX users::
+
+    @InProceedings{ uieda-proc-scipy-2013,
+      author    = { Leonardo Uieda and Vanderlei C. Oliveira Jr and Val\'eria C. F. Barbosa },
+      title     = { Modeling the Earth with Fatiando a Terra },
+      booktitle = { Proceedings of the 12th Python in Science Conference },
+      pages     = { 96 - 103 },
+      year      = { 2013 },
+      editor    = { St\'efan van der Walt and Jarrod Millman and Katy Huff }
+    }
+
 
 Citing the methods
 ------------------
 
-Some of the methods implemented here are also **original research** by
-the developers.
-If you used any of the code below, please **also cite the method papers**.
+Please also cite the method papers of individual functions and classes. The
+proper references are found in the function, class or module documentation.
 
-Polynomial Equivalent Layer
-+++++++++++++++++++++++++++
-
-Implemented in ``fatiando.gravmag.eqlayer.PELGravity`` and
-``fatiando.gravmag.eqlayer.PELTotalField``.
+For example,  the ``fatiando.gravmag.eqlayer.PELGravity`` and
+``fatiando.gravmag.eqlayer.PELTotalField`` classes implement:
 
     Oliveira Jr, V. C., V. C. F. Barbosa, and L. Uieda (2013), Polynomial
     equivalent layer, Geophysics, 78(1), G1-G13, doi:10.1190/geo2012-0196.1.
 
-Published article: http://library.seg.org/doi/abs/10.1190/geo2012-0196.1
-<`pdf
-<http://www.leouieda.com/pdf/paper-polynomial-eqlayer-2013.pdf>`__>
-
-3D potential-field inversion by a planting algorithm
-++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-Implemented in ``fatiando.gravmag.harvester``.
-
-    Uieda, L., and V. C. F. Barbosa (2012), Robust 3D gravity gradient inversion by
-    planting anomalous densities, Geophysics, 77(4), G55-G66,
-    doi:10.1190/geo2011-0388.1
-
-Published article: http://library.seg.org/doi/abs/10.1190/geo2011-0388.1
-<`pdf
-<http://www.leouieda.com/pdf/paper-planting-anomalous-densities-2012.pdf>`__>

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -36,9 +36,9 @@ Fatiando requires the following packages:
 * `matplotlib <http://matplotlib.sourceforge.net/>`_
 * `IPython <http://ipython.org/>`__
 * `numba <http://numba.pydata.org/>`__
-* `PIL <http://www.pythonware.com/products/pil/>`_
-* `mayavi <http://code.enthought.com/projects/mayavi/>`_
+* `pillow <https://python-pillow.github.io/>`_
 * `future <http://python-future.org/>`_
+* `mayavi <http://code.enthought.com/projects/mayavi/>`_
 * A C compiler (preferably GCC or MinGW_ on Windows)
 
 The easiest and **preferred** way to get all dependencies in the latest
@@ -51,7 +51,7 @@ the many, many, many issues of compiling under Windows.
 Once you have downloaded and installed Anaconda_,
 open a terminal (or ``cmd.exe`` on Windows) and run::
 
-    conda install numpy scipy matplotlib numba ipython basemap imaging mayavi pip future
+    conda install numpy scipy matplotlib numba ipython basemap pillow mayavi pip future
 
 
 Installing Fatiando

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ matplotlib
 numba
 future
 basemap
-imaging
+pillow
 ipython
 mayavi


### PR DESCRIPTION
Fixes #215 

- [x] Don't specify the version numbers in the docs and README of the packages. This is only needed for numba (which won't run properly on older versions)
- [x] Tell people to cite the scipy 2013 proceedings instead of the figshare code. Say that you should cite the proceedings but you can link to the figshare/zenodo DOI to ensure the link always works. 
- [x] Remove the methods citation part from the docs. Most methods should be cited anyway. Instead of this, provide the citation information in the module/func/class docstrings. The docs should tell people to check those places for citation information.