### PR TITLE
Added future as a requirement to conda

### DIFF
--- a/test/requirements-conda.txt
+++ b/test/requirements-conda.txt
@@ -3,3 +3,4 @@ nose
 pep8=1.6.2
 coverage=3.7.1
 cython
+future


### PR DESCRIPTION
I installed a dev version on a fresh Ubuntu distro.  I THOUGHT this had been changed, but after updating, requirements-conda.txt lacked the 'future' package.  This pull request adds that.  I do not know how this will affect people already running Python 3, however.  (I have not modified the changelog yet, I wanted to wait until pad_arrays was buttoned up for simplicity)