### PR TITLE
New module for NMO correction

### DIFF
--- a/doc/api/seismic.nmo.rst
+++ b/doc/api/seismic.nmo.rst
@@ -1,0 +1,8 @@
+.. _fatiando_seismic_nmo:
+
+NMO (``fatiando.seismic.nmo``)
+================================================================================
+
+.. automodule:: fatiando.seismic.nmo
+   :members:
+   :show-inheritance:

--- a/fatiando/seismic/__init__.py
+++ b/fatiando/seismic/__init__.py
@@ -22,3 +22,4 @@ Tomography
 """
 from .elastic_moduli import lame_lambda, lame_mu
 from .wavelets import RickerWavelet
+from .nmo import nmo_correction

--- a/fatiando/seismic/nmo.py
+++ b/fatiando/seismic/nmo.py
@@ -1,0 +1,63 @@
+# coding: utf-8
+"""
+"""
+from __future__ import division, print_function, unicode_literals
+from future.builtins import range
+
+import numpy as np
+try:
+    from scipy.interpolate import CubicSpline
+except ImportError:
+    from scipy.interpolate import interp1d
+    CubicSpline = None
+
+from .._our_duecredit import due, Doi
+
+
+@due.dcite(Doi("10.1190/1.9781560801580"),
+           description='Seismic Data Analysis book')
+def nmo_correction(cmp, dt, offsets, velocities):
+    """
+    Performs NMO correction on the given CMP.
+
+    The units must be consistent. E.g., if dt is seconds and
+    offsets is meters, velocities must be m/s.
+
+    Uses the method described in Yilmaz (2001).
+
+    Parameters:
+
+    cmp : 2D array
+        The CMP gather that we want to correct.
+    dt : float
+        The sampling interval.
+    offsets : 1D array
+        An array with the offset of each trace in the CMP.
+    velocities : 1D array
+        An array with the NMO velocity for each time. Should
+        have the same number of elements as the CMP has samples.
+
+    Returns:
+
+    nmo : 2D array
+        The NMO corrected gather.
+
+    References:
+
+    Yilmaz, Ö. (2001), Seismic Data Analysis: Processing, Inversion, and
+    Interpretation of Seismic Data, Society of Exploration Geophysicists.
+    doi:10.1190/1.9781560801580
+
+    """
+    nmo = np.zeros_like(cmp)
+    nsamples = cmp.shape[0]
+    times = np.arange(0, nsamples*dt, dt)
+    for i, t0 in enumerate(times):
+        for j, x in enumerate(offsets):
+            t = reflection_time(t0, x, velocities[i])
+            amplitude = sample_trace(cmp[:, j], t, dt)
+            # If the time t is outside of the CMP time range,
+            # amplitude will be None.
+            if amplitude is not None:
+                nmo[i, j] = amplitude
+    return nmo


### PR DESCRIPTION
Based on the code for the NMO The Leading Edge tutorial:
https://github.com/pinga-lab/nmo-tutorial

Adds a `nmo_correction` function to seismic that applies the
correction to a given CMP using an NMO velocity profile.

### Checklist:

- [ ] Make tests for new code (at least 80% coverage)
- [ ] Create/update docstrings
- [ ] Include relevant equations and citations in docstrings
- [ ] Docstrings follow the style conventions
- [ ] Code follows PEP8 style conventions
- [ ] Code and docs have been spellchecked
- [ ] Include new dependencies in `doc/install.rst`, `environment.yml`, `ci/requirements-conda.txt` and `ci/requirements-pip.txt`.
- [ ] Documentation builds properly (run `cd doc; make` locally)
- [ ] Changelog entry (leave for last to avoid conflicts)

