### PR TITLE
create the class PointMesh and its tests

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -71,6 +71,7 @@ Meshes and collections
     TesseroidMesh
     PrismRelief
     PointGrid
+    PointMesh
 
 
 ``fatiando.utils``: Utility functions
@@ -288,4 +289,3 @@ Tesseroids (spherical prisms)
     :no-inherited-members:
 
 .. currentmodule:: fatiando.geothermal
-

--- a/fatiando/mesher/__init__.py
+++ b/fatiando/mesher/__init__.py
@@ -5,4 +5,5 @@ from __future__ import absolute_import
 
 from .geometry import Polygon, Square, Prism, Tesseroid, Sphere
 from .geometry import PolygonalPrism
-from .mesh import SquareMesh, PointGrid, PrismRelief, PrismMesh, TesseroidMesh
+from .mesh import SquareMesh, PointGrid, PointMesh
+from .mesh import PrismRelief, PrismMesh, TesseroidMesh

--- a/fatiando/mesher/__init__.py
+++ b/fatiando/mesher/__init__.py
@@ -5,5 +5,5 @@ from __future__ import absolute_import
 
 from .geometry import Polygon, Square, Prism, Tesseroid, Sphere
 from .geometry import PolygonalPrism
-from .mesh import SquareMesh, PointGrid, PointMesh
+from .mesh import SquareMesh, PointGrid, IrregularPointMesh
 from .mesh import PrismRelief, PrismMesh, TesseroidMesh

--- a/fatiando/mesher/mesh.py
+++ b/fatiando/mesher/mesh.py
@@ -388,21 +388,17 @@ class PointGrid(object):
         return cp.deepcopy(self)
 
 
-class PointMesh(object):
+class IrregularPointMesh(object):
     """
     A generic mesh of 3D point sources (spheres of unit volume).
 
     Use this as a 1D list of :class:`~fatiando.mesher.Sphere`.
 
-    Grid points are ordered like a C matrix, first each row in a column, then
-    change columns. In this case, the x direction (North-South) are the rows
-    and y (East-West) are the columns.
-
     Parameters:
 
     * x, y, z : 1d-arrays
-        The x, y, and z coordinates of each point in the mesh
-        (remember, z is positive downward).
+        The x, y, and z coordinates of each point in the mesh. Remember, x is
+        points to North, y points to East and z is positive downward.
     * props :  dict
         Physical properties of each point in the grid.
         Each key should be the name of a physical property. The corresponding
@@ -414,7 +410,7 @@ class PointMesh(object):
         >>> x = np.array([12.7, 4, 0, 23])
         >>> y = np.array([8, 34, 2, 7.1])
         >>> z = np.array([5, 6.3, 18, 0.2])
-        >>> g = PointMesh(x, y, z)
+        >>> g = IrregularPointMesh(x, y, z)
         >>> g.size
         4
         >>> g[0].center

--- a/fatiando/mesher/tests/test_mesh.py
+++ b/fatiando/mesher/tests/test_mesh.py
@@ -42,10 +42,10 @@ def test_pointmesh():
     z = np.array([5, 6.3, 18, 0.2])
     g = PointMesh(x, y, z)
     assert g.size == x.size
-    centers = [[ 12.7,   8. ,   5. ],
-               [  4. ,  34. ,   6.3],
-               [  0.,   2.,  18.],
-               [ 23. ,   7.1,   0.2]]
+    centers = [[12.7, 8., 5.],
+               [4., 34., 6.3],
+               [0., 2., 18.],
+               [23., 7.1, 0.2]]
     for point, true_c in zip(g, centers):
         npt.assert_allclose(point.center, true_c)
     for i in range(g.size):

--- a/fatiando/mesher/tests/test_mesh.py
+++ b/fatiando/mesher/tests/test_mesh.py
@@ -6,7 +6,8 @@ import numpy.testing as npt
 from pytest import raises
 
 from ... import gridder
-from ..mesh import PrismMesh, Prism, SquareMesh, PointGrid, TesseroidMesh
+from ..mesh import PrismMesh, Prism, SquareMesh, TesseroidMesh
+from ..mesh import PointGrid, PointMesh
 
 
 def test_pointgrid():
@@ -32,6 +33,25 @@ def test_pointgrid():
     npt.assert_allclose(g.z.reshape(g.shape), z + np.zeros(shape))
     npt.assert_allclose(g.dx, 10)
     npt.assert_allclose(g.dy, 2)
+
+
+def test_pointmesh():
+    "Test basic functionality of the class"
+    x = np.array([12.7, 4, 0, 23])
+    y = np.array([8, 34, 2, 7.1])
+    z = np.array([5, 6.3, 18, 0.2])
+    g = PointMesh(x, y, z)
+    assert g.size == x.size
+    centers = [[ 12.7,   8. ,   5. ],
+               [  4. ,  34. ,   6.3],
+               [  0.,   2.,  18.],
+               [ 23. ,   7.1,   0.2]]
+    for point, true_c in zip(g, centers):
+        npt.assert_allclose(point.center, true_c)
+    for i in range(g.size):
+        npt.assert_allclose(g[i].center, centers[i])
+    for i in range(-1, -(g.size + 1), -1):
+        npt.assert_allclose(g[i].center, centers[i])
 
 
 def test_pointgrid_z_array():
@@ -111,6 +131,14 @@ def test_fails_split():
     raises(ValueError, model.split, (3, 5))
 
 
+def test_point_mesh_invalid_input():
+    "it should fails for input with different sizes"
+    x = np.linspace(0., 130., 10)
+    y = np.linspace(-90., 100., 7)
+    z = np.zeros_like(x)
+    raises(AssertionError, PointMesh, x, y, z)
+
+
 def test_z_split_x():
     "model.split along x vs numpy.vsplit splits the z array correctly"
     area = [-1000., 1000., -2000., 0.]
@@ -145,6 +173,18 @@ def test_z_split_y():
 
 def test_point_grid_copy():
     p1 = PointGrid([0, 10, 2, 6], 200, (2, 3))
+    p2 = p1.copy()
+    assert p1 is not p2
+    p1.addprop('density', 3200)
+    p2.addprop('density', 2000)
+    assert p1.props['density'] != p2.props['density']
+
+
+def test_point_mesh_copy():
+    x = np.linspace(0., 13., 7)
+    y = np.linspace(-90., 100., 7)
+    z = np.zeros_like(x)
+    p1 = PointMesh(x, y, z)
     p2 = p1.copy()
     assert p1 is not p2
     p1.addprop('density', 3200)

--- a/fatiando/mesher/tests/test_mesh.py
+++ b/fatiando/mesher/tests/test_mesh.py
@@ -7,7 +7,7 @@ from pytest import raises
 
 from ... import gridder
 from ..mesh import PrismMesh, Prism, SquareMesh, TesseroidMesh
-from ..mesh import PointGrid, PointMesh
+from ..mesh import PointGrid, IrregularPointMesh
 
 
 def test_pointgrid():
@@ -35,12 +35,12 @@ def test_pointgrid():
     npt.assert_allclose(g.dy, 2)
 
 
-def test_pointmesh():
+def test_irregularpointmesh():
     "Test basic functionality of the class"
     x = np.array([12.7, 4, 0, 23])
     y = np.array([8, 34, 2, 7.1])
     z = np.array([5, 6.3, 18, 0.2])
-    g = PointMesh(x, y, z)
+    g = IrregularPointMesh(x, y, z)
     assert g.size == x.size
     centers = [[12.7, 8., 5.],
                [4., 34., 6.3],
@@ -136,7 +136,7 @@ def test_point_mesh_invalid_input():
     x = np.linspace(0., 130., 10)
     y = np.linspace(-90., 100., 7)
     z = np.zeros_like(x)
-    raises(AssertionError, PointMesh, x, y, z)
+    raises(AssertionError, IrregularPointMesh, x, y, z)
 
 
 def test_z_split_x():
@@ -184,7 +184,7 @@ def test_point_mesh_copy():
     x = np.linspace(0., 13., 7)
     y = np.linspace(-90., 100., 7)
     z = np.zeros_like(x)
-    p1 = PointMesh(x, y, z)
+    p1 = IrregularPointMesh(x, y, z)
     p2 = p1.copy()
     assert p1 is not p2
     p1.addprop('density', 3200)

--- a/fatiando/mesher/tests/test_mesh.py
+++ b/fatiando/mesher/tests/test_mesh.py
@@ -132,7 +132,7 @@ def test_fails_split():
 
 
 def test_point_mesh_invalid_input():
-    "it should fails for input with different sizes"
+    "It should fails for input with different sizes"
     x = np.linspace(0., 130., 10)
     y = np.linspace(-90., 100., 7)
     z = np.zeros_like(x)


### PR DESCRIPTION
Fixes #210 

For some applications (e.g., Equivalent Layer), we need to generate a grid of point sources (spheres of unit volume). In the current version of Fatiando, we can only create regular or scatter grids of point sources. This PR proposes a new class (PointMesh) to define a set of point sources. In this class, the source locations are defined directly by using numpy arrays of the Cartesian coordinates x, y and z.

### Checklist:

- [x] Make tests for new code (at least 80% coverage)
- [x] Create/update docstrings
- [x] Include relevant equations and citations in docstrings
- [x] Docstrings follow the style conventions
- [x] Code follows PEP8 style conventions
- [x] Code and docs have been spellchecked
- [x] Include new dependencies in `doc/install.rst`, `environment.yml`, `ci/requirements.txt`.
- [x] Documentation builds properly (run `cd doc; make` locally)
- [ ] Changelog entry (leave for last to avoid conflicts)
- [ ] First-time contributor? Add yourself to `doc/contributors.rst` (leave for last to avoid conflicts)
