### PR TITLE
Improvements to Moulder

### DIFF
--- a/fatiando/gravmag/interactive.py
+++ b/fatiando/gravmag/interactive.py
@@ -207,7 +207,7 @@ class Moulder(object):
         """
         The polygon model drawn as :class:`fatiando.mesher.Polygon` objects.
         """
-        m = [Polygon(p.xy, {'density': d})
+        m = [Polygon(p.xy, {'density': d}, force_CW=True)
              for p, d in zip(self.polygons, self.densities)]
         return m
 

--- a/fatiando/gravmag/interactive.py
+++ b/fatiando/gravmag/interactive.py
@@ -263,14 +263,6 @@ class Moulder(object):
                                 self._button_release_callback)
         self.canvas.mpl_connect('motion_notify_event',
                                 self._mouse_move_callback)
-        self.canvas.mpl_connect('draw_event',
-                                self._draw_callback)
-        # Call the cleanup and extra code for a draw event when resizing as
-        # well. This is needed so that tight_layout adjusts the figure when
-        # resized. Otherwise, tight_layout snaps only when the user clicks on
-        # the figure to do something.
-        self.canvas.mpl_connect('resize_event',
-                                self._draw_callback)
         self.density_slider.on_changed(self._set_density_callback)
         self.error_slider.on_changed(self._set_error_callback)
 
@@ -421,16 +413,6 @@ class Moulder(object):
         self.dataax.set_ylim(vmin, vmax)
         self.dataax.grid(True)
         self.canvas.draw()
-
-    def _draw_callback(self, value):
-        """
-        Callback for the canvas.draw() event.
-
-        This is called everytime the figure is redrawn. Used to do some
-        clean up and tunning whenever this is called as well, like calling
-        ``tight_layout``.
-        """
-        self.figure.tight_layout()
 
     def _set_error_callback(self, value):
         """

--- a/fatiando/gravmag/interactive.py
+++ b/fatiando/gravmag/interactive.py
@@ -666,6 +666,7 @@ class Moulder(object):
             self.canvas.draw()
         elif event.key == 'r':
             self.modelax.set_xlim(self.area[:2])
+            self.modelax.set_ylim(self.area[2:])
             self._update_data_plot()
         elif event.key == 'a':
             self._add_vertex = not self._add_vertex

--- a/fatiando/gravmag/interactive.py
+++ b/fatiando/gravmag/interactive.py
@@ -479,16 +479,14 @@ class Moulder(object):
         """
         vertices = self.polygons[self._ipoly].get_xy()
         x, y = vertices[:, 0], vertices[:, 1]
-
         # Compute the angle between the vectors to each pair of
         # vertices corresponding to each line segment of the polygon
         x1, y1 = x[:-1], y[:-1]
-        y2 = numpy.hstack((y1[1:], y1[0]))
-        x2 = numpy.hstack((x1[1:], x1[0]))
+        x2, y2 = numpy.roll(x1, -1), numpy.roll(y1, -1)
         u = numpy.vstack((x1 - event.xdata, y1 - event.ydata)).T
         v = numpy.vstack((x2 - event.xdata, y2 - event.ydata)).T
-        angle = numpy.arccos(numpy.sum(u*v, 1)/ \
-                             numpy.sqrt(numpy.sum(u**2, 1))/ \
+        angle = numpy.arccos(numpy.sum(u*v, 1) /
+                             numpy.sqrt(numpy.sum(u**2, 1)) /
                              numpy.sqrt(numpy.sum(v**2, 1)))
         position = angle.argmax() + 1
         x = numpy.hstack((x[:position], event.xdata, x[position:]))
@@ -519,7 +517,8 @@ class Moulder(object):
                     self.lines[self._ipoly].set_animated(True)
                     self.lines[self._ipoly].set_color([0, 1, 0, 0])
                     self.canvas.draw()
-                    self.background = self.canvas.copy_from_bbox(self.modelax.bbox)
+                    self.background = self.canvas.copy_from_bbox(
+                        self.modelax.bbox)
                     self.modelax.draw_artist(self.polygons[self._ipoly])
                     self.modelax.draw_artist(self.lines[self._ipoly])
                     self.canvas.blit(self.modelax.bbox)

--- a/fatiando/gravmag/interactive.py
+++ b/fatiando/gravmag/interactive.py
@@ -207,7 +207,7 @@ class Moulder(object):
         """
         The polygon model drawn as :class:`fatiando.mesher.Polygon` objects.
         """
-        m = [Polygon(p.xy, {'density': d}, force_CW=True)
+        m = [Polygon(p.xy, {'density': d}, force_clockwise=True)
              for p, d in zip(self.polygons, self.densities)]
         return m
 

--- a/fatiando/gravmag/interactive.py
+++ b/fatiando/gravmag/interactive.py
@@ -107,7 +107,7 @@ class Moulder(object):
     epsilon = 5
     # App instructions printed in the figure suptitle
     instructions = ' | '.join([
-        'n: New polygon', 'd: delete', 'click: select/move', 'a: add vertex'
+        'n: New polygon', 'd: delete', 'click: select/move', 'a: add vertex',
         'r: reset view', 'esc: cancel'])
 
     def __init__(self, area, x, z, data=None, density_range=[-2000, 2000],

--- a/fatiando/gravmag/interactive.py
+++ b/fatiando/gravmag/interactive.py
@@ -616,7 +616,7 @@ class Moulder(object):
                 line.set_color([0, 0, 0, 0])
             self.canvas.draw()
         elif event.key == 'r':
-            self.modelax.set_xlim(self.area[0], self.area[1])
+            self.modelax.set_xlim(self.area[:2])
             self._update_data_plot()
 
     def _mouse_move_callback(self, event):

--- a/fatiando/gravmag/interactive.py
+++ b/fatiando/gravmag/interactive.py
@@ -107,7 +107,8 @@ class Moulder(object):
     epsilon = 5
     # App instructions printed in the figure suptitle
     instructions = ' | '.join([
-        'n: New polygon', 'd: delete', 'click: select/move', 'esc: cancel'])
+        'n: New polygon', 'd: delete', 'click: select/move', 'r: reset view',
+        'esc: cancel'])
 
     def __init__(self, area, x, z, data=None, density_range=[-2000, 2000],
                  **kwargs):
@@ -312,13 +313,16 @@ class Moulder(object):
             The created figure
 
         """
+        sharex = kwargs.get('sharex')
+        if not sharex:
+            kwargs['sharex'] = True
         fig, axes = pyplot.subplots(2, 1, **kwargs)
         ax1, ax2 = axes
         self.predicted_line, = ax1.plot(self.x, self.predicted, '-r')
         if self.data is not None:
             self.data_line, = ax1.plot(self.x, self.data, '.k')
         ax1.set_ylabel('Gravity anomaly (mGal)')
-        ax1.set_xlabel('x (m)', labelpad=-10)
+        ax2.set_xlabel('x (m)', labelpad=-10)
         ax1.set_xlim(self.area[:2])
         ax1.set_ylim((-200, 200))
         ax1.grid(True)
@@ -565,8 +569,6 @@ class Moulder(object):
         """
         What to do when a key is pressed on the keyboard.
         """
-        if event.inaxes is None:
-            return
         if event.key == 'd':
             if self._drawing and self._xy:
                 self._xy.pop()
@@ -631,6 +633,9 @@ class Moulder(object):
                 line.set_animated(False)
                 line.set_color([0, 0, 0, 0])
             self.canvas.draw()
+        elif event.key == 'r':
+            self.modelax.set_xlim(self.area[0], self.area[1])
+            self._update_data_plot()
 
     def _mouse_move_callback(self, event):
         """

--- a/fatiando/mesher/geometry.py
+++ b/fatiando/mesher/geometry.py
@@ -72,9 +72,11 @@ class Polygon(GeometricElement):
 
     """
 
-    def __init__(self, vertices, props=None):
+    def __init__(self, vertices, props=None, force_CW=False):
         super().__init__(props)
         self._vertices = np.asarray(vertices)
+        if force_CW:
+            self.set_orientation("CW")
 
     @property
     def vertices(self):
@@ -91,6 +93,54 @@ class Polygon(GeometricElement):
     @property
     def y(self):
         return self.vertices[:, 1]
+
+    @property
+    def orientation(self):
+        area = self.area(absolute=False)
+        if area < 0:
+            return "CW"
+        else:
+            return "CCW"
+
+    def set_orientation(self, orientation):
+        if orientation not in ["CW", "CWW"]:
+            raise ValueError("Orientation must be 'CW' or 'CCW'")
+        current = self.orientation
+        if orientation != current:
+            self._vertices = self._vertices[::-1]
+
+    def area(self, absolute=True):
+        """
+        Compute the area of the Polygon.
+
+        .. math::
+            A = \frac{1}{2} | \sum\limits_{i=0}^{n-1}
+                (x_{i} y_{i+1} - x_{i+1} y_{i}) |
+
+        where :math:`x_0 = x_n` and :math:`y_0 = y_n`.
+
+        If ``absolute`` is ``False`` the area is computed without applyting
+        the absolute value.
+
+        Parameters:
+
+        * absolute: bool
+            If True, the absolute value is returned, so the area is always
+            positive.
+            If False, the area can be either positive or negative.
+            The sign gives information about the orientation of the vertices:
+            If area is negative, the vertices are orientend clockwise.
+            if area is positive, the vertices are oriented counter-clockwise.
+        """
+        vertices = self.vertices
+        x, y = vertices[:, 0], vertices[:, 1]
+        x = np.hstack((x[:], x[0]))
+        y = np.hstack((y[:], y[0]))
+        area = np.sum(x*np.roll(y, 1) - np.roll(x, 1)*y)
+        if absolute:
+            return np.abs(area)
+        else:
+            return area
 
 
 class Square(Polygon):

--- a/fatiando/mesher/geometry.py
+++ b/fatiando/mesher/geometry.py
@@ -72,11 +72,11 @@ class Polygon(GeometricElement):
 
     """
 
-    def __init__(self, vertices, props=None, force_CW=False):
+    def __init__(self, vertices, props=None, force_clockwise=False):
         super().__init__(props)
         self._vertices = np.asarray(vertices)
-        if force_CW:
-            self.set_orientation("CW")
+        if force_clockwise:
+            self.set_clockwise()
 
     @property
     def vertices(self):
@@ -96,11 +96,14 @@ class Polygon(GeometricElement):
 
     @property
     def orientation(self):
-        area = self.area(absolute=False)
+        area = self.get_area(absolute=False)
         if area < 0:
             return "CW"
         else:
             return "CCW"
+
+    def set_clockwise(self):
+        self.set_orientation("CW")
 
     def set_orientation(self, orientation):
         if orientation not in ["CW", "CWW"]:
@@ -109,7 +112,7 @@ class Polygon(GeometricElement):
         if orientation != current:
             self._vertices = self._vertices[::-1]
 
-    def area(self, absolute=True):
+    def get_area(self, absolute=True):
         """
         Compute the area of the Polygon.
 


### PR DESCRIPTION
With this PR I intent to improve the gravmag.interactive.Moulder class (the interactive app to create 2D gravity models with Polygons).

I have added to Moulder:

- A `sharex=True` as default in figure creation in order to associate the model ax with the result ax.
- A new option to reset the view to the original area (in case we use the zoom or move tool)
- A new option to add new vertices to a preexisting Polygon: good when we want to edit the model.

And I have edited the mesher.Polygon class, adding a method to compute the area using the [Shoelace Formula](https://en.wikipedia.org/wiki/Shoelace_formula).
I have also added an option to avoid the application of the absolute value, so the area can be either positive or negative.
If the area is positive, the vertices of the Polygon are ordered counter-clockwise, while if it is negative, they are oriented clockwise.
This allowed me to create methods inside Polygon to change the orientation.

Using these new methods, Moulder forces the Polygons to be always clockwise in order to avoid mistakes on how the gravity field is computed (previously, if the Polygon was define counter-clockwise the gravity field was the one generated by the same Polygon with the opposite density).

### Checklist:

- [ ] Make tests for new code (at least 80% coverage)
- [ ] Create/update docstrings
- [ ] Include relevant equations and citations in docstrings
- [ ] Docstrings follow the style conventions
- [ ] Code follows PEP8 style conventions
- [ ] Code and docs have been spellchecked
- [ ] Include new dependencies in `doc/install.rst`, `environment.yml`, `ci/requirements.txt`.
- [ ] Documentation builds properly (run `cd doc; make` locally)
- [ ] Changelog entry (leave for last to avoid conflicts)
- [ ] First-time contributor? Add yourself to `doc/contributors.rst` (leave for last to avoid conflicts)
